### PR TITLE
TAMAYA-358 Get CDI working with optional configvalues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
+  - openjdk9
+  - openjdk10
   - oraclejdk11

--- a/modules/injection/cdi/src/main/java/org/apache/tamaya/cdi/ConfigurationProducer.java
+++ b/modules/injection/cdi/src/main/java/org/apache/tamaya/cdi/ConfigurationProducer.java
@@ -76,6 +76,7 @@ public class ConfigurationProducer {
         // enforces the resolvability of the config
 
         String defaultTextValue = annotation.defaultValue().equals(Config.UNCONFIGURED_VALUE) ? null : annotation.defaultValue();
+        boolean required = annotation.required();
         String textValue = null;
         Configuration config = ConfigurationProvider.getConfiguration();
         if(operator!=null) {
@@ -96,9 +97,11 @@ public class ConfigurationProducer {
         ConversionContext conversionContext = createConversionContext(keyFound, keys, injectionPoint);
         Object value = convertValue(textValue, conversionContext, injectionPoint, customConverter);
         if (value == null) {
-            throw new ConfigException(String.format(
+            if (required){
+                throw new ConfigException(String.format(
                     "Can't resolve any of the possible config keys: %s to the required target type: %s, supported formats: %s",
                     keys, conversionContext.getTargetType(), conversionContext.getSupportedFormats().toString()));
+            }
         }
         LOGGER.finest(String.format("Injecting %s for key %s in class %s", keyFound, value.toString(), injectionPoint.toString()));
         return value;

--- a/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/ConfiguredBTest.java
+++ b/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/ConfiguredBTest.java
@@ -20,22 +20,13 @@
 package org.apache.tamaya.cdi;
 
 import org.hamcrest.MatcherAssert;
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.AdditionalMatchers;
 
 import javax.enterprise.inject.spi.CDI;
-import javax.enterprise.inject.spi.Extension;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for CDI integration.

--- a/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/ConfiguredClass.java
+++ b/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/ConfiguredClass.java
@@ -22,8 +22,10 @@ package org.apache.tamaya.cdi;
 
 import org.apache.tamaya.inject.api.Config;
 
+import java.util.Optional;
 import javax.inject.Singleton;
 import java.math.BigDecimal;
+import javax.inject.Inject;
 
 /**
  * Class to be loaded from CDI to ensure fields are correctly configured using CDI injection mechanisms.
@@ -31,8 +33,21 @@ import java.math.BigDecimal;
 @Singleton
 public class ConfiguredClass{
 
+    //Config values come from the TestPropertySource during ConfigurationProducerTest
     @Config
     private String testProperty;
+    
+    //Inject+Config values come from javaconfiguration.properties during ConfiguredBTest
+    @Inject
+    @Config
+    private String injectedTestProperty;
+          
+    //@Inject will throw an NPE with a null assignment, before getting to required=false
+    //  because our provider runs in @ApplicationScope, and null @Producer has to be in
+    //  @Dependent scope (CDI 2.0 spec section 3.2).  Optional<> below is probably your
+    //  better idea.
+    @Config(value="stringMissingValue", required=false)
+    private String stringMissingValue;
 
     @Config(value = {"a.b.c.key1","a.b.c.key2","a.b.c.key3"}, defaultValue = "The current \\${JAVA_HOME} env property is ${env:JAVA_HOME}.")
     String value1;
@@ -60,11 +75,36 @@ public class ConfiguredClass{
 
     @Config("double1")
     private double doubleValue;
+ 
+    @Config
+    private Optional<String> optionalStringWithValue;
+    
+    @Inject
+    @Config
+    private Optional<String> injectedOptionalStringWithValue;
+
+    @Config(value="optionalStringMissingValue", required=false)
+    private Optional<String> optionalStringMissingValue;
+    
+    @Inject
+    @Config(value="injectedOptionalStringMissingValue", required=false)
+    private Optional<String> injectedOptionalStringMissingValue;
+    
+    @Config(value="optionalStringMissingValueWithDefault", defaultValue="optionalStringDefaultValue", required=false)
+    private Optional<String> optionalStringMissingValueWithDefault;
+    
+    @Inject
+    @Config(value="injectedOptionalStringMissingValueWithDefault", defaultValue="injectedOptionalStringDefaultValue", required=false)
+    private Optional<String> injectedOptionalStringMissingValueWithDefault;
 
     public String getTestProperty() {
         return testProperty;
     }
 
+    public String getInjectedTestProperty() {
+        return injectedTestProperty;
+    }
+    
     public String getValue1() {
         return value1;
     }
@@ -99,6 +139,34 @@ public class ConfiguredClass{
 
     public double getDoubleValue() {
         return doubleValue;
+    }
+
+    public Optional<String> getOptionalStringWithValue() {
+        return optionalStringWithValue;
+    }
+
+    public String getStringMissingValue() {
+        return stringMissingValue;
+    }
+
+    public Optional<String> getInjectedOptionalStringWithValue() {
+        return injectedOptionalStringWithValue;
+    }
+
+    public Optional<String> getOptionalStringMissingValue() {
+        return optionalStringMissingValue;
+    }
+
+    public Optional<String> getInjectedOptionalStringMissingValue() {
+        return injectedOptionalStringMissingValue;
+    }
+
+    public Optional<String> getOptionalStringMissingValueWithDefault() {
+        return optionalStringMissingValueWithDefault;
+    }
+
+    public Optional<String> getInjectedOptionalStringMissingValueWithDefault() {
+        return injectedOptionalStringMissingValueWithDefault;
     }
 
     @Override

--- a/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/cfg/TestPropertySource.java
+++ b/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/cfg/TestPropertySource.java
@@ -44,12 +44,15 @@ public class TestPropertySource implements PropertySource{
         config.put("int1", "123456");
         config.put("int2", "111222");
         config.put("testProperty", "testPropertyValue!");
+        config.put("injectedTestProperty", "injectedTestPropertyValue!");
         config.put("booleanT", "true");
         config.put("double1", "1234.5678");
         config.put("BD", "123456789123456789123456789123456789.123456789123456789123456789123456789");
         config.put("testProperty", "keys current testProperty");
         config.put("runtimeVersion", "${java.version}");
         config.put("{meta}source.type:"+getClass().getName(), "PropertySource");
+        config.put("optionalStringWithValue", "Optional value");
+        config.put("injectedOptionalStringWithValue", "Injected Optional String");
     }
 
     public int getOrdinal() {

--- a/modules/injection/cdi/src/test/resources/META-INF/javaconfiguration.properties
+++ b/modules/injection/cdi/src/test/resources/META-INF/javaconfiguration.properties
@@ -33,3 +33,5 @@ file.value = ./conf
 duration.value = 10 minutes and 57 seconds
 boolean.value = true
 integer.value = 123
+
+injectedTestProperty="injected Test Property from javaconfiguration.properties"

--- a/modules/injection/standalone/src/main/java/org/apache/tamaya/inject/internal/ConfiguredFieldImpl.java
+++ b/modules/injection/standalone/src/main/java/org/apache/tamaya/inject/internal/ConfiguredFieldImpl.java
@@ -113,7 +113,7 @@ public class ConfiguredFieldImpl implements ConfiguredField{
 
             // Check for adapter/filter
             Object value = InjectionHelper.adaptValue(this.annotatedField,
-                    TypeLiteral.of(this.annotatedField.getType()), retKey[0], evaluatedValue);
+                    TypeLiteral.of(this.annotatedField.getGenericType()), retKey[0], evaluatedValue);
             AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
                 @Override
                 public Object run() throws Exception {


### PR DESCRIPTION
There are two use cases in here, both related to injected config values that are not required.

First, the "required" parameter on the @Config annotation does not appear to have actually been referenced in the ConfigurationProducer.  I used it to wrap the exception from the original ticket which allows the annotation to inject null if it can.  It won't ever be able to under full CDI as our producer is in ApplicationScope and nulls are only allowed in Dependent scope. I put in a comment about that, and I really want to improve our docs on this.

Second, there was a bug in the type system that prevented Optional<T> from getting default values if they were set and necessary.  The parameterizedtype was getting stripped, and the OptionalConverter couldn't figure out what to actually drop in there.

I added a bunch of injection test cases and deleted some irrelevant imports too.