### PR TITLE
TAMAYA-361 Remove unused dependency on findbugs artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,12 +258,6 @@ under the License.
             </dependency>
 
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>${findbugs.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>java-hamcrest</artifactId>
                 <version>${hamcrest.version}</version>


### PR DESCRIPTION
The maven findbugs plugin continues to be used, but there is no version 3.0.4 of the `com.google.code.findbugs:jsr305` artifact.