### PR TITLE
TAMAYA-362 Implement getSnapshot method

### DIFF
--- a/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileAdapterTest.java
+++ b/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileAdapterTest.java
@@ -238,6 +238,11 @@ public class MicroprofileAdapterTest {
         public ConfigurationContext getContext() {
             throw new RuntimeException("Not implemented yet!");
         }
+
+        @Override
+        public ConfigurationSnapshot getSnapshot(Iterable<String> keys) {
+            throw new RuntimeException("Not implemented yet!");
+        }
     }
 
 }

--- a/modules/mutable-config/src/main/java/org/apache/tamaya/mutableconfig/internal/DefaultMutableConfiguration.java
+++ b/modules/mutable-config/src/main/java/org/apache/tamaya/mutableconfig/internal/DefaultMutableConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.tamaya.mutableconfig.internal;
 import org.apache.tamaya.ConfigOperator;
 import org.apache.tamaya.ConfigQuery;
 import org.apache.tamaya.Configuration;
+import org.apache.tamaya.ConfigurationSnapshot;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.mutableconfig.ChangePropagationPolicy;
 import org.apache.tamaya.mutableconfig.MutableConfiguration;
@@ -156,6 +157,11 @@ public class DefaultMutableConfiguration implements MutableConfiguration {
     @Override
     public ConfigurationContext getContext() {
         return config.getContext();
+    }
+
+    @Override
+    public ConfigurationSnapshot getSnapshot(Iterable<String> keys) {
+        return config.getSnapshot(keys);
     }
 
     private Collection<PropertySource> getPropertySources() {


### PR DESCRIPTION
Some `o.a.t.Configuration` implementations do not implement the
`::getSnapshot method`, which causes build failures.

This implements that method, where appropriate.