### PR TITLE
TAMAYA-363 Remove extraneous CORBA import

### DIFF
--- a/modules/events/src/test/java/org/apache/tamaya/events/FrozenConfigurationTest.java
+++ b/modules/events/src/test/java/org/apache/tamaya/events/FrozenConfigurationTest.java
@@ -24,7 +24,6 @@ import org.apache.tamaya.spi.ConfigurationContext;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.omg.CORBA.Any;
 
 import java.util.Collections;
 import java.util.HashMap;


### PR DESCRIPTION
The CORBA package isn't available on JDK 11, and the `Any` class is not used in this class, so this commit simply removes the import.