### PR TITLE
Post big-merge compilation cleanup

### DIFF
--- a/modules/hazelcast/src/main/java/org/apache/tamaya/hazelcast/HazelcastPropertySource.java
+++ b/modules/hazelcast/src/main/java/org/apache/tamaya/hazelcast/HazelcastPropertySource.java
@@ -21,19 +21,7 @@ package org.apache.tamaya.hazelcast;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IList;
-import com.hazelcast.core.IMap;
-import org.apache.tamaya.mutableconfig.ConfigChangeRequest;
-import org.apache.tamaya.mutableconfig.spi.MutablePropertySource;
-import org.apache.tamaya.spi.PropertyValue;
-import org.apache.tamaya.spisupport.propertysource.BasePropertySource;
-
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Distributed Propertysource using a in-memory hazelcast cluster.

--- a/modules/hazelcast/src/test/java/org/apache/tamaya/hazelcast/HazelcastPropertySourceTest.java
+++ b/modules/hazelcast/src/test/java/org/apache/tamaya/hazelcast/HazelcastPropertySourceTest.java
@@ -36,13 +36,15 @@ import static org.junit.Assert.*;
  * Created by atsticks on 03.11.16.
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class HazelcaszPropertySourceTest {
+public class HazelcastPropertySourceTest {
 
-    private static HazelcastInstance hz = HazelcastUtil.getHazelcastInstance();
-    private HazelcastPropertySource hps = new HazelcastPropertySource();
+    private static HazelcastInstance hz;
+    private static HazelcastPropertySource hps;
 
     @BeforeClass
     public static void start() {
+        hps = new HazelcastPropertySource();
+        hz = hps.getHazelcastInstance();
         IMap<Object, Object> map = hz.getMap("config3");
         map.put("k1", "v1");
         map.put("k2", "v2");

--- a/modules/injection/standalone/src/main/java/org/apache/tamaya/inject/internal/InjectionHelper.java
+++ b/modules/injection/standalone/src/main/java/org/apache/tamaya/inject/internal/InjectionHelper.java
@@ -41,6 +41,7 @@ import org.apache.tamaya.resolver.spi.ExpressionEvaluator;
 import org.apache.tamaya.spi.ConfigurationContext;
 import org.apache.tamaya.spi.ConversionContext;
 import org.apache.tamaya.spi.PropertyConverter;
+import org.apache.tamaya.spi.PropertyValue;
 import org.apache.tamaya.spi.ServiceContextManager;
 
 
@@ -225,7 +226,7 @@ final class InjectionHelper {
         ExpressionEvaluator evaluator = ServiceContextManager.getServiceContext(classLoader)
                 .getService(ExpressionEvaluator.class);
         if (evaluator != null) {
-            return evaluator.evaluateExpression("<injection>", expression, true);
+            return evaluator.evaluateExpression(PropertyValue.createValue("<injection>", expression), true).getValue();
         }
         return expression;
     }


### PR DESCRIPTION
This fixes the errors that we're discussing on the mailing list around `evaluateExpression` in the injection standalone.  It also fixes an error in hazelcast that the previous error masked.

In my testing, this un-blocks the sandbox builds.