### PR TITLE
Add timeout value to events.ObservedConfigTest

### DIFF
--- a/modules/events/src/test/java/org/apache/tamaya/events/ObservedConfigTest.java
+++ b/modules/events/src/test/java/org/apache/tamaya/events/ObservedConfigTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class ObservedConfigTest {
 
-    @Test
+    @Test(timeout=60000)
     public void testChangingConfig() throws IOException {
         ConfigEventManager.getInstance().setChangeMonitoringPeriod(100L);
         ConfigEventManager.getInstance().enableChangeMonitoring(true);


### PR DESCRIPTION
The Apache Jenkins server seems to occasionally get "stuck" on this test. This just adds a 60 second timeout, since a failed test is much better than a test that hangs indefinitely.

See [this log](https://builds.apache.org/job/Tamaya-Extensions-Master/1985/console) for an example.