### PR TITLE
Clean up OSGi/Manifest metadata

### DIFF
--- a/modules/collections/bnd.bnd
+++ b/modules/collections/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.collections
 Import-Package: \

--- a/modules/consul/bnd.bnd
+++ b/modules/consul/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.consul
 Import-Package: \

--- a/modules/etcd/bnd.bnd
+++ b/modules/etcd/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.etcd
 Import-Package: \

--- a/modules/events/bnd.bnd
+++ b/modules/events/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.events,\
 	org.apache.tamaya.events.spi

--- a/modules/features/bnd.bnd
+++ b/modules/features/bnd.bnd
@@ -13,12 +13,12 @@ Automatic-Module-Name: org.apache.tamaya.features
 Bundle-Version: ${version}.${tstamp}
 Bundle-Name: Apache Tamaya - Features
 Bundle-SymbolicName: org.apache.tamaya.features
-Bundle-Description: Apacha Tamaya Confi - Features
+Bundle-Description: Apacha Tamaya Config - Features
 Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.features

--- a/modules/filter/bnd.bnd
+++ b/modules/filter/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.filter
 Import-Package: \

--- a/modules/formats/base/bnd.bnd
+++ b/modules/formats/base/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.format,\
 	org.apache.tamaya.format.formats

--- a/modules/formats/json/bnd.bnd
+++ b/modules/formats/json/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.json
 Import-Package: \

--- a/modules/formats/yaml/bnd.bnd
+++ b/modules/formats/yaml/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.yaml
 Import-Package: \

--- a/modules/functions/bnd.bnd
+++ b/modules/functions/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.functions
 Import-Package: \

--- a/modules/hazelcast/bnd.bnd
+++ b/modules/hazelcast/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.hazelcast
 Import-Package: \

--- a/modules/injection/cdi/bnd.bnd
+++ b/modules/injection/cdi/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.inject.cdi,\
 	org.apache.tamaya.inject.extras

--- a/modules/injection/injection-api/bnd.bnd
+++ b/modules/injection/injection-api/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: API
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.inject.api,\
 	org.apache.tamaya.inject.spi

--- a/modules/injection/standalone/bnd.bnd
+++ b/modules/injection/standalone/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.inject
 Import-Package: \

--- a/modules/jndi/bnd.bnd
+++ b/modules/jndi/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.jndi
 Import-Package: \

--- a/modules/microprofile/bnd.bnd
+++ b/modules/microprofile/bnd.bnd
@@ -18,7 +18,7 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
 Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.microprofile,\

--- a/modules/mutable-config/bnd.bnd
+++ b/modules/mutable-config/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: API
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.mutableconfig,\
     org.apache.tamaya.mutableconfig.propertysources,\

--- a/modules/optional/bnd.bnd
+++ b/modules/optional/bnd.bnd
@@ -18,7 +18,7 @@ Bundle-Category: API
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.optional

--- a/modules/osgi/common/bnd.bnd
+++ b/modules/osgi/common/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Bundle-Activator: org.apache.tamaya.osgi.Activator
 Export-Package: \
 	org.apache.tamaya.osgi,\

--- a/modules/osgi/gogo-shell/bnd.bnd
+++ b/modules/osgi/gogo-shell/bnd.bnd
@@ -19,8 +19,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.gogo.shell
 Import-Package: \

--- a/modules/osgi/injection/bnd.bnd
+++ b/modules/osgi/injection/bnd.bnd
@@ -19,8 +19,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Import-Package: \
     org.osgi.service.cm,\
     org.osgi.framework,\

--- a/modules/osgi/karaf-shell/bnd.bnd
+++ b/modules/osgi/karaf-shell/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.karaf.shell
 Import-Package: \

--- a/modules/osgi/updater/bnd.bnd
+++ b/modules/osgi/updater/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Bundle-Activator: org.apache.tamaya.osgi.updater.Activator
 Export-Package: \
 	org.apache.tamaya.osgi.updater

--- a/modules/resolver/bnd.bnd
+++ b/modules/resolver/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.resolver,\
     	org.apache.tamaya.resolver.spi

--- a/modules/resources/bnd.bnd
+++ b/modules/resources/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.resource
 Private-Package: \

--- a/modules/spring/bnd.bnd
+++ b/modules/spring/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.integration.spring
 Import-Package: \

--- a/pom.xml
+++ b/pom.xml
@@ -549,12 +549,32 @@ under the License.
                 </plugin>
 
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>1.4</version>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <shortRevisionLength>8</shortRevisionLength>
+                    </configuration>
+                </plugin>
+
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <configuration>
                         <archive>
                             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                             <addMavenDescriptor>false</addMavenDescriptor>
+                            <manifest>
+                              <addDefaultImplementationEntries>false</addDefaultImplementationEntries>
+                            </manifest>
                             <manifestEntries>
                                 <Specification-Title>Apache ${project.name}</Specification-Title>
                                 <Specification-Version>${project.version}</Specification-Version>
@@ -563,7 +583,6 @@ under the License.
                                 <Implementation-Version>${project.version} ${buildNumber}</Implementation-Version>
                                 <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
                                 <SCM-Revision>${buildNumber}</SCM-Revision>
-                                <SCM-url>${project.scm.url}</SCM-url>
                             </manifestEntries>
                         </archive>
                     </configuration>
@@ -862,6 +881,10 @@ under the License.
                     <source>${maven.compile.sourceLevel}</source>
                     <target>${maven.compile.targetLevel}</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>


### PR DESCRIPTION
Related to TAMAYA-331

As with https://github.com/apache/incubator-tamaya/pull/30, this adds the `buildnumber-maven-plugin` in order to correctly populate `${buildNumber}` in the `MANIFEST.MF`. This also cleans up some metadata values in `MANIFEST.MF`.