### PR TITLE
Remove duplicate import

### DIFF
--- a/modules/filter/pom.xml
+++ b/modules/filter/pom.xml
@@ -76,11 +76,6 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.tamaya</groupId>
-            <artifactId>tamaya-spisupport</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
             <version>5.0.0</version>


### PR DESCRIPTION
The `tamaya-spisupport` module is imported twice.
This removes the duplicate entry.