### PR TITLE
TAMAYA-216: Migrate test assertions to assertj

### DIFF
--- a/examples/02-resolver-example/pom.xml
+++ b/examples/02-resolver-example/pom.xml
@@ -45,10 +45,6 @@ under the License.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/examples/03-injection-example/pom.xml
+++ b/examples/03-injection-example/pom.xml
@@ -51,10 +51,6 @@ under the License.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/examples/04-events-example/pom.xml
+++ b/examples/04-events-example/pom.xml
@@ -60,10 +60,6 @@ under the License.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/examples/05-spring-example/pom.xml
+++ b/examples/05-spring-example/pom.xml
@@ -66,10 +66,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>java-hamcrest</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>

--- a/modules/collections/pom.xml
+++ b/modules/collections/pom.xml
@@ -52,11 +52,6 @@ under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/modules/collections/pom.xml
+++ b/modules/collections/pom.xml
@@ -56,6 +56,10 @@ under the License.
             <artifactId>java-hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/modules/collections/src/test/java/org/apache/tamaya/collections/CollectionAdvancedTests.java
+++ b/modules/collections/src/test/java/org/apache/tamaya/collections/CollectionAdvancedTests.java
@@ -26,9 +26,7 @@ import java.util.Currency;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 16.02.16.
@@ -47,12 +45,12 @@ public class CollectionAdvancedTests {
     public void testCustomSeparator(){
         Configuration config = Configuration.current();
         List<String> items = config.get("sep-list", new TypeLiteral<List<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(3, items.size());
-        assertEquals("a,b,c", items.get(0));
-        assertEquals("d,e,f", items.get(1));
-        assertEquals("g,h,i", items.get(2));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(3);
+        assertThat("a,b,c").isEqualTo(items.get(0));
+        assertThat("d,e,f").isEqualTo(items.get(1));
+        assertThat("g,h,i").isEqualTo(items.get(2));
     }
 
     /**
@@ -66,12 +64,12 @@ public class CollectionAdvancedTests {
     public void testTypedContent(){
         Configuration config = Configuration.current();
         List<Currency> items = config.get("currency-list", new TypeLiteral<List<Currency>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(3, items.size());
-        assertEquals("CHF", items.get(0).getCurrencyCode());
-        assertEquals("USD", items.get(1).getCurrencyCode());
-        assertEquals("USS", items.get(2).getCurrencyCode());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(3);
+        assertThat("CHF").isEqualTo(items.get(0).getCurrencyCode());
+        assertThat("USD").isEqualTo(items.get(1).getCurrencyCode());
+        assertThat("USS").isEqualTo(items.get(2).getCurrencyCode());
     }
 
     /**
@@ -86,12 +84,12 @@ public class CollectionAdvancedTests {
     public void testCustomParser(){
         Configuration config = Configuration.current();
         List<String> items = config.get("parser-list", new TypeLiteral<List<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(3, items.size());
-        assertEquals("(A)", items.get(0));
-        assertEquals("(B)", items.get(1));
-        assertEquals("(C)", items.get(2));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(3);
+        assertThat("(A)").isEqualTo(items.get(0));
+        assertThat("(B)").isEqualTo(items.get(1));
+        assertThat("(C)").isEqualTo(items.get(2));
     }
 
     /**
@@ -106,11 +104,11 @@ public class CollectionAdvancedTests {
     public void testCustomMapParser(){
         Configuration config = Configuration.current();
         Map<String,String> items = config.get("redefined-map", Map.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(3, items.size());
-        assertEquals("none", items.get("0"));
-        assertEquals("single", items.get("1"));
-        assertEquals("any", items.get("2"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(3);
+        assertThat("none").isEqualTo(items.get("0"));
+        assertThat("single").isEqualTo(items.get("1"));
+        assertThat("any").isEqualTo(items.get("2"));
     }
 }

--- a/modules/collections/src/test/java/org/apache/tamaya/collections/CollectionsBaseTests.java
+++ b/modules/collections/src/test/java/org/apache/tamaya/collections/CollectionsBaseTests.java
@@ -24,9 +24,7 @@ import org.junit.Test;
 
 import java.util.*;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Basic tests for Tamaya collection support. Relevant configs for this tests:
@@ -40,187 +38,187 @@ public class CollectionsBaseTests {
     public void testList_String(){
         Configuration config = Configuration.current();
         List<String> items = config.get("base.items", new TypeLiteral<List<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items = (List<String>) config.get("base.items", List.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
     }
 
     @Test
     public void testArrayList_String(){
         Configuration config = Configuration.current();
         ArrayList<String> items = config.get("base.items", new TypeLiteral<ArrayList<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items = (ArrayList<String>) config.get("base.items", ArrayList.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
     }
 
     @Test
     public void testLinkedList_String(){
         Configuration config = Configuration.current();
         LinkedList<String> items = config.get("base.items", new TypeLiteral<LinkedList<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items = (LinkedList<String>) config.get("base.items", LinkedList.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
     }
 
     @Test
     public void testSet_String(){
         Configuration config = Configuration.current();
         Set<String> items = config.get("base.items", new TypeLiteral<Set<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items = (Set<String>) config.get("base.items", Set.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
     }
 
     @Test
     public void testSortedSet_String(){
         Configuration config = Configuration.current();
         Set<String> items = config.get("base.items", new TypeLiteral<SortedSet<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items = (SortedSet<String>) config.get("base.items", SortedSet.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
     }
 
     @Test
     public void testHashSet_String(){
         Configuration config = Configuration.current();
         Set<String> items = config.get("base.items", new TypeLiteral<HashSet<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items = (HashSet<String>) config.get("base.items", HashSet.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
     }
 
     @Test
     public void testTreeSet_String(){
         Configuration config = Configuration.current();
         TreeSet<String> items = config.get("base.items", new TypeLiteral<TreeSet<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items = (TreeSet<String>) config.get("base.items", TreeSet.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
     }
 
     @Test
     public void testMap_String(){
         Configuration config = Configuration.current();
         Map<String,String> items = config.get("base.map", new TypeLiteral<Map<String,String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
         items = (Map<String,String>) config.get("base.map", Map.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
     }
 
     @Test
     public void testHashMap_String(){
         Configuration config = Configuration.current();
         Map<String,String> items = config.get("base.map", new TypeLiteral<HashMap<String,String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
         items = (HashMap<String,String>) config.get("base.map", HashMap.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
     }
 
     @Test
     public void testSortedMap_String(){
         Configuration config = Configuration.current();
         Map<String,String> items = config.get("base.map", new TypeLiteral<SortedMap<String,String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
         items = (Map<String,String>) config.get("base.map", SortedMap.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
     }
 
     @Test
     public void testTreeMap_String(){
         Configuration config = Configuration.current();
         TreeMap<String,String> items = config.get("base.map", new TypeLiteral<TreeMap<String,String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
         items =  config.get("base.map", TreeMap.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
     }
 
     @Test
     public void testCollection_String(){
         Configuration config = Configuration.current();
         Collection<String> items = config.get("base.items", new TypeLiteral<Collection<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items = (Collection<String>) config.get("base.items", Collection.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
     }
 }

--- a/modules/collections/src/test/java/org/apache/tamaya/collections/CollectionsTypedReadOnlyTests.java
+++ b/modules/collections/src/test/java/org/apache/tamaya/collections/CollectionsTypedReadOnlyTests.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 
 import java.util.*;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Basic tests for Tamaya collection support. Relevant configs for this tests:
@@ -41,9 +40,9 @@ public class CollectionsTypedReadOnlyTests {
     public void testArrayListList_1(){
         Configuration config = Configuration.current();
         List<String> items = config.get("typed.arraylist", new TypeLiteral<List<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items.add("test");
     }
 
@@ -51,9 +50,9 @@ public class CollectionsTypedReadOnlyTests {
     public void testArrayListList_2(){
         Configuration config = Configuration.current();
         List<String> items = (List<String>) config.get("typed.arraylist", List.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items.add("test");
     }
 
@@ -61,9 +60,9 @@ public class CollectionsTypedReadOnlyTests {
     public void testLinkedListList_1(){
         Configuration config = Configuration.current();
         List<String> items = config.get("typed.linkedlist", new TypeLiteral<List<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items.add("test");
     }
 
@@ -71,9 +70,9 @@ public class CollectionsTypedReadOnlyTests {
     public void testLinkedListList_2(){
         Configuration config = Configuration.current();
         List<String> items = (List<String>) config.get("typed.linkedlist", List.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items.add("test");
     }
 
@@ -82,18 +81,18 @@ public class CollectionsTypedReadOnlyTests {
     public void testHashSet_1(){
         Configuration config = Configuration.current();
         Set<String> items = config.get("typed.hashset", new TypeLiteral<Set<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items.add("test");
     }
     @Test
     public void testHashSet_2(){
         Configuration config = Configuration.current();
         Set<String> items = (Set<String>) config.get("typed.hashset", Set.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items.add("test");
     }
 
@@ -101,18 +100,18 @@ public class CollectionsTypedReadOnlyTests {
     public void testTreeSet_1(){
         Configuration config = Configuration.current();
         Set<String> items = config.get("typed.treeset", new TypeLiteral<Set<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items.add("test");
     }
     @Test
     public void testTreeSet_2(){
         Configuration config = Configuration.current();
         Set<String> items = items = (Set<String>) config.get("typed.treeset", Set.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
         items.add("test");
     }
 
@@ -120,26 +119,26 @@ public class CollectionsTypedReadOnlyTests {
     public void testHashMap_1(){
         Configuration config = Configuration.current();
         Map<String,String> items = config.get("typed.hashmap", new TypeLiteral<Map<String,String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
         items.put("g","hjhhj");
     }
     @Test(expected=UnsupportedOperationException.class)
     public void testHashMap_2(){
         Configuration config = Configuration.current();
         Map<String,String> items = (Map<String,String>) config.get("typed.hashmap", Map.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
         items.put("g","hjhhj");
     }
 
@@ -148,26 +147,26 @@ public class CollectionsTypedReadOnlyTests {
     public void testTreeMap_1(){
         Configuration config = Configuration.current();
         Map<String,String> items = config.get("typed.treemap", new TypeLiteral<Map<String,String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
         items.put("g","hjhhj");
     }
     @Test
     public void testTreeMap_2(){
         Configuration config = Configuration.current();
         Map<String,String> items = (Map<String,String>) config.get("typed.treemap", Map.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
         items.put("g","hjhhj");
     }
 

--- a/modules/collections/src/test/java/org/apache/tamaya/collections/CollectionsTypedTests.java
+++ b/modules/collections/src/test/java/org/apache/tamaya/collections/CollectionsTypedTests.java
@@ -24,10 +24,7 @@ import org.junit.Test;
 
 import java.util.*;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Basic tests for Tamaya collection support. Relevant configs for this tests:
@@ -41,30 +38,30 @@ public class CollectionsTypedTests {
     public void testArrayListList_String(){
         Configuration config = Configuration.current();
         List<String> items = config.get("typed2.arraylist", new TypeLiteral<List<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof ArrayList);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(ArrayList.class);
         items = (List<String>) config.get("typed2.arraylist", List.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof ArrayList);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(ArrayList.class);
     }
 
     @Test
     public void testLinkedListList_String(){
         Configuration config = Configuration.current();
         List<String> items = config.get("typed2.linkedlist", new TypeLiteral<List<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof LinkedList);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(LinkedList.class);
         items = (List<String>) config.get("typed2.linkedlist", List.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof LinkedList);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(LinkedList.class);
     }
 
 
@@ -72,136 +69,136 @@ public class CollectionsTypedTests {
     public void testHashSet_String(){
         Configuration config = Configuration.current();
         Set<String> items = config.get("typed2.hashset", new TypeLiteral<Set<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof HashSet);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(HashSet.class);
         items = (Set<String>) config.get("typed2.hashset", Set.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof HashSet);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(HashSet.class);
     }
 
     @Test
     public void testTreeSet_String(){
         Configuration config = Configuration.current();
         Set<String> items = config.get("typed2.treeset", new TypeLiteral<Set<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof TreeSet);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(TreeSet.class);
         items = (Set<String>) config.get("typed2.treeset", Set.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof TreeSet);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(TreeSet.class);
     }
 
     @Test
     public void testHashMap_String(){
         Configuration config = Configuration.current();
         Map<String,String> items = config.get("typed2.hashmap", new TypeLiteral<Map<String,String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
-        assertTrue(items instanceof HashMap);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
+        assertThat(items).isInstanceOf(HashMap.class);
         items = (Map<String,String>) config.get("typed2.hashmap", Map.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
-        assertTrue(items instanceof HashMap);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
+        assertThat(items).isInstanceOf(HashMap.class);
     }
 
     @Test
     public void testTreeMap_String(){
         Configuration config = Configuration.current();
         Map<String,String> items = config.get("typed2.treemap", new TypeLiteral<Map<String,String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
-        assertTrue(items instanceof TreeMap);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
+        assertThat(items).isInstanceOf(TreeMap.class);
         items = (Map<String,String>) config.get("typed2.treemap", Map.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(4, items.size());
-        assertEquals("a", items.get("1"));
-        assertEquals("b", items.get("2"));
-        assertEquals("c", items.get("3"));
-        assertEquals(" ", items.get("4"));
-        assertTrue(items instanceof TreeMap);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(4);
+        assertThat("a").isEqualTo(items.get("1"));
+        assertThat("b").isEqualTo(items.get("2"));
+        assertThat("c").isEqualTo(items.get("3"));
+        assertThat(" ").isEqualTo(items.get("4"));
+        assertThat(items).isInstanceOf(TreeMap.class);
     }
 
     @Test
     public void testCollection_HashSet(){
         Configuration config = Configuration.current();
         Collection<String> items = config.get("typed2.hashset", new TypeLiteral<Collection<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof HashSet);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(HashSet.class);
         items = (Collection<String>) config.get("typed2.hashset", Collection.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof HashSet);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(HashSet.class);
     }
 
     @Test
     public void testCollection_TreeSet(){
         Configuration config = Configuration.current();
         Collection<String> items = config.get("typed2.treeset", new TypeLiteral<Collection<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof TreeSet);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(TreeSet.class);
         items = (Collection<String>) config.get("typed2.treeset", Collection.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof TreeSet);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(TreeSet.class);
     }
 
     @Test
     public void testCollection_ArrayList(){
         Configuration config = Configuration.current();
         Collection<String> items = config.get("typed2.arraylist", new TypeLiteral<Collection<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof ArrayList);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(ArrayList.class);
         items = (Collection<String>) config.get("typed2.arraylist", Collection.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof ArrayList);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(ArrayList.class);
     }
 
     @Test
     public void testCollection_LinkedList(){
         Configuration config = Configuration.current();
         Collection<String> items = config.get("typed2.linkedlist", new TypeLiteral<Collection<String>>(){});
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof LinkedList);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(LinkedList.class);
         items = (Collection<String>) config.get("typed2.linkedlist", Collection.class);
-        assertNotNull(items);
-        assertFalse(items.isEmpty());
-        assertEquals(10, items.size());
-        assertTrue(items instanceof LinkedList);
+        assertThat(items).isNotNull();
+        assertThat(items.isEmpty()).isFalse();
+        assertThat(items).hasSize(10);
+        assertThat(items).isInstanceOf(LinkedList.class);
     }
 
 }

--- a/modules/consul/pom.xml
+++ b/modules/consul/pom.xml
@@ -38,6 +38,10 @@ under the License.
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.tamaya</groupId>

--- a/modules/consul/pom.xml
+++ b/modules/consul/pom.xml
@@ -35,10 +35,6 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/modules/consul/src/test/java/org/apache/tamaya/consul/ConsulPropertySourceTest.java
+++ b/modules/consul/src/test/java/org/apache/tamaya/consul/ConsulPropertySourceTest.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 07.01.16.
@@ -42,31 +41,31 @@ public class ConsulPropertySourceTest {
 
     @Test
     public void testGetOrdinal() throws Exception {
-        assertEquals(1000, propertySource.getOrdinal());
+        assertThat(1000).isEqualTo(propertySource.getOrdinal());
     }
 
     @Test
     public void testGetDefaultOrdinal() throws Exception {
-        assertEquals(1000, propertySource.getDefaultOrdinal());
+        assertThat(1000).isEqualTo(propertySource.getDefaultOrdinal());
     }
 
     @Test
     public void testGetName() throws Exception {
-        assertEquals("consul", propertySource.getName());
+        assertThat("consul").isEqualTo(propertySource.getName());
     }
 
     @Test
     public void testGet() throws Exception {
         Map<String,PropertyValue> props = propertySource.getProperties();
         for(Map.Entry<String,PropertyValue> en:props.entrySet()){
-            assertNotNull("Key not found: " + en.getKey(), propertySource.get(en.getKey()));
+            assertThat(propertySource.get(en.getKey())).isNotNull();
         }
     }
 
     @Test
     public void testGetProperties() throws Exception {
         Map<String,PropertyValue> props = propertySource.getProperties();
-        assertNotNull(props);
+        assertThat(props).isNotNull();
     }
 
 }

--- a/modules/consul/src/test/java/org/apache/tamaya/consul/ConsulWriteTest.java
+++ b/modules/consul/src/test/java/org/apache/tamaya/consul/ConsulWriteTest.java
@@ -18,11 +18,6 @@
  */
 package org.apache.tamaya.consul;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -32,6 +27,8 @@ import org.apache.tamaya.mutableconfig.ConfigChangeRequest;
 import org.apache.tamaya.spi.PropertyValue;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for the consul backend integration for writing to the consul backend.
@@ -69,18 +66,18 @@ public class ConsulWriteTest {
         ConfigChangeRequest request = new ConfigChangeRequest("testDelete");
         request.put(taID, "testDelete");
         propertySource.applyChange(request);
-        assertEquals(taID.toString(), propertySource.get("testDelete").getValue());
-        assertNotNull(propertySource.get("_testDelete.createdIndex"));
+        assertThat(taID.toString()).isEqualTo(propertySource.get("testDelete").getValue());
+        assertThat(propertySource.get("_testDelete.createdIndex")).isNotNull();
         request = new ConfigChangeRequest("testDelete2");
         request.remove("testDelete");
         propertySource.applyChange(request);
-        assertNull(propertySource.get("testDelete"));
+        assertThat(propertySource.get("testDelete")).isNull();
     }
 
     @Test
     public void testGetProperties() throws Exception {
         if(!execute)return;
         Map<String,PropertyValue> result = propertySource.getProperties();
-        assertTrue(result.isEmpty());
+        assertThat(result.isEmpty()).isTrue();
     }
 }

--- a/modules/etcd/pom.xml
+++ b/modules/etcd/pom.xml
@@ -39,6 +39,10 @@ under the License.
             <artifactId>java-hamcrest</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.tamaya</groupId>
             <artifactId>tamaya-core</artifactId>
             <version>${project.parent.version}</version>

--- a/modules/etcd/pom.xml
+++ b/modules/etcd/pom.xml
@@ -35,10 +35,6 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/modules/etcd/src/test/java/org/apache/tamaya/etcd/EtcdAccessorTest.java
+++ b/modules/etcd/src/test/java/org/apache/tamaya/etcd/EtcdAccessorTest.java
@@ -25,7 +25,7 @@ import java.net.MalformedURLException;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for the etcd backend integration. You must have setCurrent a system property so, theses tests are executed, e.g.
@@ -51,14 +51,14 @@ public class EtcdAccessorTest {
     @Test
     public void testGetVersion() throws Exception {
         if(!execute)return;
-        assertEquals(accessor.getVersion(), "etcd 0.4.9");
+        assertThat(accessor.getVersion()).isEqualTo("etcd 0.4.9");
     }
 
     @Test
     public void testGet() throws Exception {
         if(!execute)return;
         Map<String,String> result = accessor.get("test1");
-        assertNotNull(result);
+        assertThat(result).isNotNull();
     }
 
     @Test
@@ -66,8 +66,8 @@ public class EtcdAccessorTest {
         if(!execute)return;
         String value = UUID.randomUUID().toString();
         Map<String,String> result = accessor.set("testSetNormal", value);
-        assertNull(result.get("_testSetNormal.ttl"));
-        assertEquals(value, accessor.get("testSetNormal").get("testSetNormal"));
+        assertThat(result.get("_testSetNormal.ttl")).isNull();
+        assertThat(value).isEqualTo(accessor.get("testSetNormal").get("testSetNormal"));
     }
 
     @Test
@@ -75,8 +75,8 @@ public class EtcdAccessorTest {
         if(!execute)return;
         String value = UUID.randomUUID().toString();
         Map<String,String> result = accessor.set("testSetNormal2", value, null);
-        assertNull(result.get("_testSetNormal2.ttl"));
-        assertEquals(value, accessor.get("testSetNormal2").get("testSetNormal2"));
+        assertThat(result.get("_testSetNormal2.ttl")).isNull();
+        assertThat(value).isEqualTo(accessor.get("testSetNormal2").get("testSetNormal2"));
     }
 
     @Test
@@ -84,11 +84,11 @@ public class EtcdAccessorTest {
         if(!execute)return;
         String value = UUID.randomUUID().toString();
         Map<String,String> result = accessor.set("testSetWithTTL", value, 1);
-        assertNotNull(result.get("_testSetWithTTL.ttl"));
-        assertEquals(value, accessor.get("testSetWithTTL").get("testSetWithTTL"));
+        assertThat(result.get("_testSetWithTTL.ttl")).isNotNull();
+        assertThat(value).isEqualTo(accessor.get("testSetWithTTL").get("testSetWithTTL"));
         Thread.sleep(2000L);
         result = accessor.get("testSetWithTTL");
-        assertNull(result.get("testSetWithTTL"));
+        assertThat(result.get("testSetWithTTL")).isNull();
     }
 
     @Test
@@ -96,11 +96,11 @@ public class EtcdAccessorTest {
         if(!execute)return;
         String value = UUID.randomUUID().toString();
         Map<String,String> result = accessor.set("testDelete", value, null);
-        assertEquals(value, accessor.get("testDelete").get("testDelete"));
-        assertNotNull(result.get("_testDelete.createdIndex"));
+        assertThat(value).isEqualTo(accessor.get("testDelete").get("testDelete"));
+        assertThat(result.get("_testDelete.createdIndex")).isNotNull();
         result = accessor.delete("testDelete");
-        assertEquals(value, result.get("_testDelete.prevNode.createValue"));
-        assertNull(accessor.get("testDelete").get("testDelete"));
+        assertThat(value).isEqualTo(result.get("_testDelete.prevNode.createValue"));
+        assertThat(accessor.get("testDelete").get("testDelete")).isNull();
     }
 
     @Test
@@ -109,8 +109,8 @@ public class EtcdAccessorTest {
         String value = UUID.randomUUID().toString();
         accessor.set("testGetProperties1", value);
         Map<String,String> result = accessor.getProperties("");
-        assertNotNull(result);
-        assertEquals(value, result.get("testGetProperties1"));
-        assertNotNull(result.get("_testGetProperties1.createdIndex"));
+        assertThat(result).isNotNull();
+        assertThat(value).isEqualTo(result.get("testGetProperties1"));
+        assertThat(result.get("_testGetProperties1.createdIndex")).isNotNull();
     }
 }

--- a/modules/etcd/src/test/java/org/apache/tamaya/etcd/EtcdPropertySourceTest.java
+++ b/modules/etcd/src/test/java/org/apache/tamaya/etcd/EtcdPropertySourceTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 07.01.16.
@@ -41,35 +40,35 @@ public class EtcdPropertySourceTest {
 
     @Test
     public void testGetOrdinal() throws Exception {
-        assertEquals(1000, propertySource.getOrdinal());
+        assertThat(1000).isEqualTo(propertySource.getOrdinal());
     }
 
     @Test
     public void testGetDefaultOrdinal() throws Exception {
-        assertEquals(1000, propertySource.getDefaultOrdinal());
+        assertThat(1000).isEqualTo(propertySource.getDefaultOrdinal());
     }
 
     @Test
     public void testGetName() throws Exception {
-        assertEquals("etcd", propertySource.getName());
+        assertThat("etcd").isEqualTo(propertySource.getName());
     }
 
     @Test
     public void testGet() throws Exception {
         Map<String,PropertyValue> props = propertySource.getProperties();
         for(Map.Entry<String,PropertyValue> en:props.entrySet()){
-            assertNotNull("Key not found: " + en.getKey(), propertySource.get(en.getKey()));
+            assertThat(propertySource.get(en.getKey())).isNotNull();
         }
     }
 
     @Test
     public void testGetProperties() throws Exception {
         Map<String,PropertyValue> props = propertySource.getProperties();
-        assertNotNull(props);
+        assertThat(props).isNotNull();
     }
 
     @Test
     public void testIsScannable() throws Exception {
-        assertTrue(propertySource.isScannable());
+        assertThat(propertySource.isScannable()).isTrue();
     }
 }

--- a/modules/events/pom.xml
+++ b/modules/events/pom.xml
@@ -71,10 +71,6 @@ under the License.
             <version>${tamaya-apicore.version}</version>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>

--- a/modules/events/pom.xml
+++ b/modules/events/pom.xml
@@ -79,7 +79,6 @@ under the License.
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/events/src/test/java/org/apache/tamaya/events/ConfigEventManagerTest.java
+++ b/modules/events/src/test/java/org/apache/tamaya/events/ConfigEventManagerTest.java
@@ -20,7 +20,7 @@ package org.apache.tamaya.events;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link ConfigEventManager}.
@@ -39,10 +39,10 @@ public class ConfigEventManagerTest {
         };
         ConfigEventManager.getInstance().addListener(testListener);
         ConfigEventManager.getInstance().fireEvent(new SimpleEvent("Event1"));
-        assertEquals(testAddListenerValue, "Event1");
+        assertThat(testAddListenerValue).isEqualTo("Event1");
         ConfigEventManager.getInstance().removeListener(testListener);
         ConfigEventManager.getInstance().fireEvent(new SimpleEvent("Event2"));
-        assertEquals(testAddListenerValue, "Event1");
+        assertThat(testAddListenerValue).isEqualTo("Event1");
     }
 
     @Test
@@ -55,10 +55,10 @@ public class ConfigEventManagerTest {
         };
         ConfigEventManager.getInstance().addListener(testListener);
         ConfigEventManager.getInstance().fireEvent(new SimpleEvent("Event1"));
-        assertEquals(testAddListenerValue, "Event1");
+        assertThat(testAddListenerValue).isEqualTo("Event1");
         ConfigEventManager.getInstance().removeListener(testListener);
         ConfigEventManager.getInstance().fireEvent(new SimpleEvent("Event2"));
-        assertEquals(testAddListenerValue, "Event1");
+        assertThat(testAddListenerValue).isEqualTo("Event1");
     }
 
 }

--- a/modules/events/src/test/java/org/apache/tamaya/events/ConfigurationChangeTest.java
+++ b/modules/events/src/test/java/org/apache/tamaya/events/ConfigurationChangeTest.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Test class for {@link ConfigurationChange}.
  */
@@ -41,17 +41,18 @@ public class ConfigurationChangeTest {
     public void testGetConfiguration() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).build();
-        assertNotNull(change);
-        assertTrue(change.getUpdatedSize()==0);
-        assertTrue(change.getAddedSize()==0);
-        assertTrue(change.getRemovedSize()==0);
-        assertTrue(change.getChanges().size()==0);
+        assertThat(change).isNotNull();
+        assertThat(change.getUpdatedSize()).isEqualTo(0);
+        assertThat(change.getAddedSize()).isEqualTo(0);
+        assertThat(change.getRemovedSize()).isEqualTo(0);
+        assertThat(change.getChanges().size()).isEqualTo(0);
         for (Map.Entry<String, String> en : config.getProperties().entrySet()) {
             if (!"[meta]frozenAt".equals(en.getKey())) {
                 if(en.getKey().contains("random.new")){ // dynamic generated value!
                     continue;
                 }
-                assertEquals("Error for " + en.getKey(), en.getValue(), change.getResource().get(en.getKey()));
+                assertThat(en.getValue()).describedAs("Error for " + en.getKey())
+                    .isEqualTo(change.getResource().get(en.getKey()));
             }
         }
     }
@@ -60,9 +61,9 @@ public class ConfigurationChangeTest {
     public void testGetVersion() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).build();
-        assertNotNull(change.getVersion());
+        assertThat(change.getVersion()).isNotNull();
         change = ConfigurationChangeBuilder.of(config).setVersion("version2").build();
-        assertEquals("version2", change.getVersion());
+        assertThat("version2").isEqualTo(change.getVersion());
     }
 
     @Test
@@ -71,80 +72,80 @@ public class ConfigurationChangeTest {
         Configuration config = Configuration.current();
         Thread.sleep(20L);
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).build();
-        assertTrue((change.getTimestamp() - startTS) > 0L);
+        assertThat((change.getTimestamp() - startTS) > 0L).isTrue();
         change = ConfigurationChangeBuilder.of(config).setTimestamp(10L).build();
-        assertEquals(10L, change.getTimestamp());
+        assertThat(10L).isEqualTo(change.getTimestamp());
     }
 
     @Test
     public void testGetEvents() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).removeKey("key1", "key2").build();
-        assertTrue(change.getChanges().size() == 2);
+        assertThat(change.getChanges().size()).isEqualTo(2);
         change = ConfigurationChangeBuilder.of(config).addChange("key1Added", "value1Added").build();
-        assertTrue(change.getChanges().size() == 1);
+        assertThat(change.getChanges().size()).isEqualTo(1);
     }
 
     @Test
     public void testGetRemovedSize() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).removeKey("java.version", "key2").build();
-        assertTrue(change.getRemovedSize() == 2);
-        assertTrue(change.getAddedSize() == 0);
+        assertThat(change.getRemovedSize()).isEqualTo(2);
+        assertThat(change.getAddedSize()).isEqualTo(0);
     }
 
     @Test
     public void testGetAddedSize() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).addChange("key1", "key2").build();
-        assertTrue(change.getAddedSize() == 1);
-        assertTrue(change.getRemovedSize() == 0);
+        assertThat(change.getAddedSize()).isEqualTo(1);
+        assertThat(change.getRemovedSize()).isEqualTo(0);
     }
 
     @Test
     public void testGetUpdatedSize() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).addChange("java.version", "1.8").build();
-        assertTrue(change.getUpdatedSize() == 1);
+        assertThat(change.getUpdatedSize()).isEqualTo(1);
     }
 
     @Test
     public void testIsRemoved() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).removeKey("java.version").build();
-        assertTrue(change.isRemoved("java.version"));
+        assertThat(change.isRemoved("java.version")).isTrue();
     }
 
     @Test
     public void testIsAdded() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).addChange("key1", "key2").build();
-        assertTrue(change.isAdded("key1"));
+        assertThat(change.isAdded("key1")).isTrue();
     }
 
     @Test
     public void testIsUpdated() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).addChange("java.version", "1.8").build();
-        assertTrue(change.isUpdated("java.version"));
+        assertThat(change.isUpdated("java.version")).isTrue();
     }
 
     @Test
     public void testContainsKey() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).addChange("key1", "key2").build();
-        assertTrue(change.isKeyAffected("key1"));
-        assertFalse(change.isKeyAffected("key2"));
+        assertThat(change.isKeyAffected("key1")).isTrue();
+        assertThat(change.isKeyAffected("key2")).isFalse();
         change = ConfigurationChangeBuilder.of(config).removeKey("java.version").build();
-        assertFalse(change.isKeyAffected("java.version"));
-        assertFalse(change.isKeyAffected("key2"));
+        assertThat(change.isKeyAffected("java.version")).isFalse();
+        assertThat(change.isKeyAffected("key2")).isFalse();
     }
 
     @Test
     public void testIsEmpty() throws Exception {
         Configuration config = Configuration.current();
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).build();
-        assertTrue(change.isEmpty());
+        assertThat(change.isEmpty()).isTrue();
     }
 
     @Test
@@ -153,10 +154,10 @@ public class ConfigurationChangeTest {
         ConfigurationChange change = ConfigurationChangeBuilder.of(config).removeKey("java.version").build();
         String toString =
                 change.toString();
-        assertTrue(toString.contains("timestamp"));
-        assertTrue(toString.contains("change-id"));
-        assertTrue(toString.contains("snapshot-id"));
-        assertFalse(toString.contains("key1"));
-        assertFalse(toString.contains("key2"));
+        assertThat(toString.contains("timestamp")).isTrue();
+        assertThat(toString.contains("change-id")).isTrue();
+        assertThat(toString.contains("snapshot-id")).isTrue();
+        assertThat(toString.contains("key1")).isFalse();
+        assertThat(toString.contains("key2")).isFalse();
     }
 }

--- a/modules/events/src/test/java/org/apache/tamaya/events/FrozenPropertySourceTest.java
+++ b/modules/events/src/test/java/org/apache/tamaya/events/FrozenPropertySourceTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link org.apache.tamaya.events.FrozenPropertySource}.
@@ -38,47 +38,46 @@ public class FrozenPropertySourceTest {
     @Test
     public void testOf() throws Exception {
         PropertySource ps = FrozenPropertySource.of(myPS);
-        assertNotNull(ps);
+        assertThat(ps).isNotNull();
     }
 
     @Test
     public void testGetName() throws Exception {
         PropertySource ps = FrozenPropertySource.of(myPS);
         String name = ps.getName();
-        assertNotNull(name);
-        assertEquals(name, ps.getName());
+        assertThat(name).isNotNull();
+        assertThat(name).isEqualTo(ps.getName());
     }
 
     @Test
     public void testGetOrdinal() throws Exception {
         PropertySource ps = FrozenPropertySource.of(myPS);
-        assertEquals(PropertySourceComparator.getOrdinal(myPS),
-                PropertySourceComparator.getOrdinal(ps));
+        assertThat(PropertySourceComparator.getOrdinal(myPS)).isEqualTo(PropertySourceComparator.getOrdinal(ps));
     }
 
     @Test
     public void testGet() throws Exception {
         PropertySource ps = FrozenPropertySource.of(myPS);
-        assertNotNull(ps);
+        assertThat(ps).isNotNull();
         for (Map.Entry<String, PropertyValue> e : myPS.getProperties().entrySet()) {
-            assertEquals(ps.get(e.getKey()).getValue(), e.getValue().getValue());
+            assertThat(ps.get(e.getKey()).getValue()).isEqualTo(e.getValue().getValue());
         }
     }
 
     @Test
     public void testGetProperties() throws Exception {
         PropertySource ps = FrozenPropertySource.of(myPS);
-        assertNotNull(ps);
-        assertNotNull(ps.getProperties());
-        assertFalse(ps.getProperties().isEmpty());
+        assertThat(ps).isNotNull();
+        assertThat(ps.getProperties()).isNotNull();
+        assertThat(ps.getProperties().isEmpty()).isFalse();
     }
 
     @Test
     public void testEquals() throws Exception {
         PropertySource ps1 = FrozenPropertySource.of(myPS);
         PropertySource ps2 = FrozenPropertySource.of(myPS);
-        assertEquals(ps1.getName(), ps2.getName());
-        assertEquals(ps1.getProperties().size(), ps2.getProperties().size());
+        assertThat(ps1.getName()).isEqualTo(ps2.getName());
+        assertThat(ps1.getProperties().size()).isEqualTo(ps2.getProperties().size());
     }
 
     @Test
@@ -102,8 +101,8 @@ public class FrozenPropertySourceTest {
     public void testToString() throws Exception {
         PropertySource ps = FrozenPropertySource.of(myPS);
         String toString = ps.toString();
-        assertNotNull(toString);
-        assertTrue(toString.contains("FrozenPropertySource"));
-        assertTrue(toString.contains(myPS.getName()));
+        assertThat(toString).isNotNull();
+        assertThat(toString.contains("FrozenPropertySource")).isTrue();
+        assertThat(toString.contains(myPS.getName())).isTrue();
     }
 }

--- a/modules/events/src/test/java/org/apache/tamaya/events/ObservedConfigTest.java
+++ b/modules/events/src/test/java/org/apache/tamaya/events/ObservedConfigTest.java
@@ -21,7 +21,8 @@ package org.apache.tamaya.events;
 import org.junit.Test;
 
 import java.io.IOException;
-import static org.junit.Assert.assertTrue;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test (currently manual) to test configuration changes.
@@ -40,12 +41,12 @@ public class ObservedConfigTest {
             }
             ConfigEvent<?> event = MyConfigObserver.event;
             if(event!=null) {
-                assertTrue(event instanceof ConfigurationChange);
+                assertThat(event).isInstanceOf(ConfigurationChange.class);
                 ConfigurationChange cChange = (ConfigurationChange) event;
                 if(cChange.isAdded("random.new")){
                     MyConfigObserver.event=null;
                 }else {
-                    assertTrue(cChange.isUpdated("random.new"));
+                    assertThat(cChange.isUpdated("random.new")).isTrue();
                     break;
                 }
             }

--- a/modules/events/src/test/java/org/apache/tamaya/events/PropertySourceChangeTest.java
+++ b/modules/events/src/test/java/org/apache/tamaya/events/PropertySourceChangeTest.java
@@ -19,7 +19,6 @@
 package org.apache.tamaya.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -72,7 +71,7 @@ public class PropertySourceChangeTest {
                 .addChanges(
                         new EnvironmentPropertySource()
                 ).build();
-        assertTrue(change.getRemovedSize() > 0);
+        assertThat(change.getRemovedSize() > 0).isTrue();
     }
 
     @Test
@@ -81,7 +80,7 @@ public class PropertySourceChangeTest {
                 .addChanges(
                         new EnvironmentPropertySource()
                 ).build();
-        assertTrue(change.getAddedSize() > 0);
+        assertThat(change.getAddedSize() > 0).isTrue();
     }
 
     @Test
@@ -116,7 +115,7 @@ public class PropertySourceChangeTest {
                         new MapPropertySource("addableMap", addableMap)
                 )
                 .build();
-        assertTrue(change.getUpdatedSize() > 0);
+        assertThat(change.getUpdatedSize() > 0).isTrue();
     }
 
     @Test
@@ -189,7 +188,7 @@ public class PropertySourceChangeTest {
     public void testIsEmpty() throws Exception {
         PropertySourceChange change = PropertySourceChangeBuilder.of(new EnvironmentPropertySource())
                 .build();
-        assertTrue(change.isEmpty());
+        assertThat(change.isEmpty()).isTrue();
         change = PropertySourceChangeBuilder.of(new EnvironmentPropertySource())
                 .addChanges(
                         myPS

--- a/modules/events/src/test/java/org/apache/tamaya/events/internal/DefaultConfigEventManagerSpiTest.java
+++ b/modules/events/src/test/java/org/apache/tamaya/events/internal/DefaultConfigEventManagerSpiTest.java
@@ -23,7 +23,7 @@ import org.apache.tamaya.events.ConfigEventListener;
 import org.apache.tamaya.events.SimpleEvent;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link DefaultConfigEventManagerSpi}.
@@ -43,10 +43,10 @@ public class DefaultConfigEventManagerSpiTest {
         };
         spi.addListener(testListener);
         spi.fireEvent(new SimpleEvent("Event1"));
-        assertEquals(testAddListenerValue, "Event1");
+        assertThat(testAddListenerValue).isEqualTo("Event1");
         spi.removeListener(testListener);
         spi.fireEvent(new SimpleEvent("Event2"));
-        assertEquals(testAddListenerValue, "Event1");
+        assertThat(testAddListenerValue).isEqualTo("Event1");
 
     }
 

--- a/modules/features/pom.xml
+++ b/modules/features/pom.xml
@@ -46,10 +46,6 @@ under the License.
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/features/pom.xml
+++ b/modules/features/pom.xml
@@ -54,6 +54,10 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.tamaya.ext</groupId>
             <artifactId>tamaya-injection</artifactId>
             <version>${project.version}</version>

--- a/modules/features/src/test/java/org/apache/tamaya/features/FeaturesTest.java
+++ b/modules/features/src/test/java/org/apache/tamaya/features/FeaturesTest.java
@@ -20,7 +20,7 @@ package org.apache.tamaya.features;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests if feature are seen. Created by atsticks on 19.03.17.
@@ -28,88 +28,88 @@ import static org.junit.Assert.*;
 public class FeaturesTest {
     @Test
     public void eventsAvailable() throws Exception {
-        assertTrue(Features.eventsAvailable());
+        assertThat(Features.eventsAvailable()).isTrue();
     }
 
     @Test
     public void formatsAvailable() throws Exception {
-        assertTrue(Features.formatsAvailable());
+        assertThat(Features.formatsAvailable()).isTrue();
     }
 
     @Test
     public void tamayaCoreAvailable() throws Exception {
-        assertTrue(Features.tamayaCoreAvailable());
+        assertThat(Features.tamayaCoreAvailable()).isTrue();
     }
 
     @Test
     public void injectionCDIAvailable() throws Exception {
-        assertTrue(Features.injectionCDIAvailable());
+        assertThat(Features.injectionCDIAvailable()).isTrue();
     }
 
     @Test
     public void injectionStandaloneAvailable() throws Exception {
-        assertTrue(Features.injectionStandaloneAvailable());
+        assertThat(Features.injectionStandaloneAvailable()).isTrue();
     }
 
     @Test
     public void mutableConfigAvailable() throws Exception {
-        assertTrue(Features.mutableConfigAvailable());
+        assertThat(Features.mutableConfigAvailable()).isTrue();
     }
 
     @Test
     public void optionalAvailable() throws Exception {
-        assertTrue(Features.optionalAvailable());
+        assertThat(Features.optionalAvailable()).isTrue();
     }
 
     @Test
     public void resolverAvailable() throws Exception {
-        assertTrue(Features.resolverAvailable());
+        assertThat(Features.resolverAvailable()).isTrue();
     }
 
     @Test
     public void resourcesAvailable() throws Exception {
-        assertTrue(Features.resourcesAvailable());
+        assertThat(Features.resourcesAvailable()).isTrue();
     }
 
     @Test
     public void spiSupportAvailable() throws Exception {
-        assertTrue(Features.spiSupportAvailable());
+        assertThat(Features.spiSupportAvailable()).isTrue();
     }
 
     @Test
     public void filterSupportAvailable() throws Exception {
-        assertTrue(Features.filterSupportAvailable());
+        assertThat(Features.filterSupportAvailable()).isTrue();
     }
 
     @Test
     public void springAvailable() throws Exception {
-        assertTrue(Features.springAvailable());
+        assertThat(Features.springAvailable()).isTrue();
     }
 
     @Test
     public void jndiAvailable() throws Exception {
-        assertTrue(Features.jndiAvailable());
+        assertThat(Features.jndiAvailable()).isTrue();
     }
 
     @Test
     public void extSpringCoreAvailable() throws Exception {
-        assertTrue(Features.extSpringCoreAvailable());
+        assertThat(Features.extSpringCoreAvailable()).isTrue();
     }
 
     @Test
     public void extOSGIAvailable() throws Exception {
-        assertTrue(Features.extOSGIAvailable());
+        assertThat(Features.extOSGIAvailable()).isTrue();
     }
 
     @Test
     public void extJndiAvailable() throws Exception {
-        assertTrue(Features.extJndiAvailable());
+        assertThat(Features.extJndiAvailable()).isTrue();
     }
 
     @Test
     public void checkClassIsLoadable() throws Exception {
-        assertTrue(Features.checkClassIsLoadable("java.lang.String"));
-        assertFalse(Features.checkClassIsLoadable("foo.Bar"));
+        assertThat(Features.checkClassIsLoadable("java.lang.String")).isTrue();
+        assertThat(Features.checkClassIsLoadable("foo.Bar")).isFalse();
     }
 
 }

--- a/modules/features/src/test/java/org/apache/tamaya/features/FeaturesTestNoOnly.java
+++ b/modules/features/src/test/java/org/apache/tamaya/features/FeaturesTestNoOnly.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests if feature are not seen, using an empty class loader. Created by atsticks on 19.03.17.
@@ -48,88 +47,88 @@ public class FeaturesTestNoOnly {
 
     @Test
     public void eventsAvailable() throws Exception {
-        assertFalse(Features.eventsAvailable());
+        assertThat(Features.eventsAvailable()).isFalse();
     }
 
     @Test
     public void formatsAvailable() throws Exception {
-        assertFalse(Features.formatsAvailable());
+        assertThat(Features.formatsAvailable()).isFalse();
     }
 
     @Test
     public void tamayaCoreAvailable() throws Exception {
-        assertFalse(Features.tamayaCoreAvailable());
+        assertThat(Features.tamayaCoreAvailable()).isFalse();
     }
 
     @Test
     public void injectionCDIAvailable() throws Exception {
-        assertFalse(Features.injectionCDIAvailable());
+        assertThat(Features.injectionCDIAvailable()).isFalse();
     }
 
     @Test
     public void injectionStandaloneAvailable() throws Exception {
-        assertFalse(Features.injectionStandaloneAvailable());
+        assertThat(Features.injectionStandaloneAvailable()).isFalse();
     }
 
     @Test
     public void mutableConfigAvailable() throws Exception {
-        assertFalse(Features.mutableConfigAvailable());
+        assertThat(Features.mutableConfigAvailable()).isFalse();
     }
 
     @Test
     public void optionalAvailable() throws Exception {
-        assertFalse(Features.optionalAvailable());
+        assertThat(Features.optionalAvailable()).isFalse();
     }
 
     @Test
     public void resolverAvailable() throws Exception {
-        assertFalse(Features.resolverAvailable());
+        assertThat(Features.resolverAvailable()).isFalse();
     }
 
     @Test
     public void resourcesAvailable() throws Exception {
-        assertFalse(Features.resourcesAvailable());
+        assertThat(Features.resourcesAvailable()).isFalse();
     }
 
     @Test
     public void spiSupportAvailable() throws Exception {
-        assertFalse(Features.spiSupportAvailable());
+        assertThat(Features.spiSupportAvailable()).isFalse();
     }
 
     @Test
     public void filterSupportAvailable() throws Exception {
-        assertFalse(Features.filterSupportAvailable());
+        assertThat(Features.filterSupportAvailable()).isFalse();
     }
 
     @Test
     public void springAvailable() throws Exception {
-        assertFalse(Features.springAvailable());
+        assertThat(Features.springAvailable()).isFalse();
     }
 
     @Test
     public void jndiAvailable() throws Exception {
-        assertFalse(Features.jndiAvailable());
+        assertThat(Features.jndiAvailable()).isFalse();
     }
 
     @Test
     public void extSpringCoreAvailable() throws Exception {
-        assertFalse(Features.extSpringCoreAvailable());
+        assertThat(Features.extSpringCoreAvailable()).isFalse();
     }
 
     @Test
     public void extOSGIAvailable() throws Exception {
-        assertFalse(Features.extOSGIAvailable());
+        assertThat(Features.extOSGIAvailable()).isFalse();
     }
 
     @Test
     public void extJndiAvailable() throws Exception {
-        assertTrue(Features.extJndiAvailable());
+        assertThat(Features.extJndiAvailable()).isTrue();
     }
 
     @Test
     public void checkClassIsLoadable() throws Exception {
-        assertTrue(Features.checkClassIsLoadable("java.lang.String"));
-        assertFalse(Features.checkClassIsLoadable("foo.Bar"));
+        assertThat(Features.checkClassIsLoadable("java.lang.String")).isTrue();
+        assertThat(Features.checkClassIsLoadable("foo.Bar")).isFalse();
     }
 
 }

--- a/modules/filter/pom.xml
+++ b/modules/filter/pom.xml
@@ -68,10 +68,6 @@ under the License.
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/filter/pom.xml
+++ b/modules/filter/pom.xml
@@ -76,6 +76,10 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
             <version>5.0.0</version>

--- a/modules/filter/src/test/java/org/apache/tamaya/filter/ConfigurationFilterTest.java
+++ b/modules/filter/src/test/java/org/apache/tamaya/filter/ConfigurationFilterTest.java
@@ -24,7 +24,7 @@ import org.apache.tamaya.spi.PropertyFilter;
 import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link ThreadBasedConfigurationFilter}. Created by atsticks on 11.02.16.
@@ -34,15 +34,15 @@ public class ConfigurationFilterTest {
     @Test
     public void testMetadataFiltered() throws Exception {
         ThreadBasedConfigurationFilter.setMetadataFiltered(true);
-        assertTrue(ThreadBasedConfigurationFilter.isMetadataFiltered());
+        assertThat(ThreadBasedConfigurationFilter.isMetadataFiltered()).isTrue();
         ThreadBasedConfigurationFilter.setMetadataFiltered(false);
-        assertFalse(ThreadBasedConfigurationFilter.isMetadataFiltered());
+        assertThat(ThreadBasedConfigurationFilter.isMetadataFiltered()).isFalse();
     }
 
     @Test
     public void testGetSingleFilters() throws Exception {
         Configuration config = Configuration.current();
-        assertNotNull(ThreadBasedConfigurationFilter.getSingleValueFilterContext());
+        assertThat(ThreadBasedConfigurationFilter.getSingleValueFilterContext()).isNotNull();
         PropertyFilter testFilter = new PropertyFilter() {
             @Override
             public PropertyValue filterProperty(PropertyValue value, FilterContext ctx) {
@@ -50,15 +50,15 @@ public class ConfigurationFilterTest {
             }
         };
         ThreadBasedConfigurationFilter.getSingleValueFilterContext().addFilter(testFilter);
-        assertEquals("user.home:testGetSingleFilters", config.get("user.home"));
+        assertThat("user.home:testGetSingleFilters").isEqualTo(config.get("user.home"));
         ThreadBasedConfigurationFilter.getSingleValueFilterContext().removeFilter(testFilter);
-        assertNotSame("user.home:testGetSingleFilters", config.get("user.home"));
+        assertThat("user.home:testGetSingleFilters").isNotSameAs(config.get("user.home"));
     }
 
     @Test
     public void testRemoveSingleFiltersAt0() throws Exception {
         Configuration config = Configuration.current();
-        assertNotNull(ThreadBasedConfigurationFilter.getSingleValueFilterContext());
+        assertThat(ThreadBasedConfigurationFilter.getSingleValueFilterContext()).isNotNull();
         PropertyFilter testFilter = new PropertyFilter() {
             @Override
             public PropertyValue filterProperty(PropertyValue value, FilterContext ctx) {
@@ -66,15 +66,15 @@ public class ConfigurationFilterTest {
             }
         };
         ThreadBasedConfigurationFilter.getSingleValueFilterContext().addFilter(testFilter);
-        assertEquals("user.home:testGetSingleFilters", config.get("user.home"));
+        assertThat("user.home:testGetSingleFilters").isEqualTo(config.get("user.home"));
         ThreadBasedConfigurationFilter.getSingleValueFilterContext().removeFilter(0);
-        assertNotSame("user.home:testGetSingleFilters", config.get("user.home"));
+        assertThat("user.home:testGetSingleFilters").isNotSameAs(config.get("user.home"));
     }
 
     @Test
     public void testGetMapFilters() throws Exception {
         Configuration config = Configuration.current();
-        assertNotNull(ThreadBasedConfigurationFilter.getMapFilterContext());
+        assertThat(ThreadBasedConfigurationFilter.getMapFilterContext()).isNotNull();
         PropertyFilter testFilter = new PropertyFilter() {
             @Override
             public PropertyValue filterProperty(PropertyValue value, FilterContext ctx) {
@@ -82,15 +82,15 @@ public class ConfigurationFilterTest {
             }
         };
         ThreadBasedConfigurationFilter.getMapFilterContext().addFilter(testFilter);
-        assertEquals("user.home:testGetMapFilters", config.getProperties().get("user.home"));
+        assertThat("user.home:testGetMapFilters").isEqualTo(config.getProperties().get("user.home"));
         ThreadBasedConfigurationFilter.getSingleValueFilterContext().removeFilter(testFilter);
-        assertNotSame("user.home:testGetSingleFilters", config.getProperties().get("user.home"));
+        assertThat("user.home:testGetSingleFilters").isNotSameAs(config.getProperties().get("user.home"));
     }
 
     @Test
     public void testRemoveMapFilterAt0() throws Exception {
         Configuration config = Configuration.current();
-        assertNotNull(ThreadBasedConfigurationFilter.getMapFilterContext());
+        assertThat(ThreadBasedConfigurationFilter.getMapFilterContext()).isNotNull();
         PropertyFilter testFilter = new PropertyFilter() {
             @Override
             public PropertyValue filterProperty(PropertyValue value, FilterContext ctx) {
@@ -98,15 +98,15 @@ public class ConfigurationFilterTest {
             }
         };
         ThreadBasedConfigurationFilter.getMapFilterContext().addFilter(testFilter);
-        assertEquals("user.home:testGetMapFilters", config.getProperties().get("user.home"));
+        assertThat("user.home:testGetMapFilters").isEqualTo(config.getProperties().get("user.home"));
         ThreadBasedConfigurationFilter.getMapFilterContext().removeFilter(0);
-        assertNotSame("user.home:testGetSingleFilters", config.getProperties().get("user.home"));
+        assertThat("user.home:testGetSingleFilters").isNotSameAs(config.getProperties().get("user.home"));
     }
 
     @Test
     public void testClearFilters() throws Exception {
         Configuration config = Configuration.current();
-        assertNotNull(ThreadBasedConfigurationFilter.getSingleValueFilterContext());
+        assertThat(ThreadBasedConfigurationFilter.getSingleValueFilterContext()).isNotNull();
         PropertyFilter testFilter = new PropertyFilter() {
             @Override
             public PropertyValue filterProperty(PropertyValue value, FilterContext ctx) {
@@ -114,9 +114,9 @@ public class ConfigurationFilterTest {
             }
         };
         ThreadBasedConfigurationFilter.getSingleValueFilterContext().addFilter(testFilter);
-        assertEquals("user.home:testGetSingleFilters", config.get("user.home"));
+        assertThat("user.home:testGetSingleFilters").isEqualTo(config.get("user.home"));
         ThreadBasedConfigurationFilter.cleanupFilterContext();
-        assertNotSame("user.home:testGetSingleFilters", config.get("user.home"));
+        assertThat("user.home:testGetSingleFilters").isNotSameAs(config.get("user.home"));
     }
 
 }

--- a/modules/filter/src/test/java/org/apache/tamaya/filter/ProgrammableFilterTest.java
+++ b/modules/filter/src/test/java/org/apache/tamaya/filter/ProgrammableFilterTest.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link ThreadFilterContext}. Created by atsticks on 11.02.16.
@@ -49,23 +49,23 @@ public class ProgrammableFilterTest {
         FilterContext context1 = new FilterContext(test1Property, map, context);
         FilterContext context2 = new FilterContext(test2Property, map, context);
         FilterContext context3 = new FilterContext(test3Property, map, context);
-        assertEquals(filter.filterProperty(test1Property, context1), test1Property);
-        assertEquals(filter.filterProperty(test2Property, context2), test2Property);
-        assertEquals(filter.filterProperty(test3Property, context3), test3Property);
+        assertThat(filter.filterProperty(test1Property, context1)).isEqualTo(test1Property);
+        assertThat(filter.filterProperty(test2Property, context2)).isEqualTo(test2Property);
+        assertThat(filter.filterProperty(test3Property, context3)).isEqualTo(test3Property);
         RegexPropertyFilter regexFilter = new RegexPropertyFilter();
         regexFilter.setIncludes("test\\..*");
         filter.addFilter(regexFilter);
-        assertNull(filter.filterProperty(test1Property, context1));
-        assertNull(filter.filterProperty(test2Property, context2));
-        assertEquals(filter.filterProperty(test3Property, context3), test3Property);
+        assertThat(filter.filterProperty(test1Property, context1)).isNull();
+        assertThat(filter.filterProperty(test2Property, context2)).isNull();
+        assertThat(filter.filterProperty(test3Property, context3)).isEqualTo(test3Property);
         filter.removeFilter(0);
-        assertEquals(filter.filterProperty(test1Property, context1), test1Property);
-        assertEquals(filter.filterProperty(test2Property, context2), test2Property);
-        assertEquals(filter.filterProperty(test3Property, context3), test3Property);
+        assertThat(filter.filterProperty(test1Property, context1)).isEqualTo(test1Property);
+        assertThat(filter.filterProperty(test2Property, context2)).isEqualTo(test2Property);
+        assertThat(filter.filterProperty(test3Property, context3)).isEqualTo(test3Property);
         filter.addFilter(0, regexFilter);
-        assertNull(filter.filterProperty(test1Property, context1));
-        assertNull(filter.filterProperty(test2Property, context2));
-        assertEquals(filter.filterProperty(test3Property, context3), test3Property);
+        assertThat(filter.filterProperty(test1Property, context1)).isNull();
+        assertThat(filter.filterProperty(test2Property, context2)).isNull();
+        assertThat(filter.filterProperty(test3Property, context3)).isEqualTo(test3Property);
     }
 
     @Test
@@ -81,17 +81,17 @@ public class ProgrammableFilterTest {
         FilterContext context1 = new FilterContext(test1Property, context);
         FilterContext context2 = new FilterContext(test2Property, context);
         FilterContext context3 = new FilterContext(test3Property, context);
-        assertEquals(filter.filterProperty(test1Property, context1), test1Property);
-        assertEquals(filter.filterProperty(test2Property, context2), test2Property);
-        assertEquals(filter.filterProperty(test3Property, context3), test3Property);
+        assertThat(filter.filterProperty(test1Property, context1)).isEqualTo(test1Property);
+        assertThat(filter.filterProperty(test2Property, context2)).isEqualTo(test2Property);
+        assertThat(filter.filterProperty(test3Property, context3)).isEqualTo(test3Property);
         filter.addFilter(regexFilter);
-        assertEquals(filter.filterProperty(test1Property, context1), test1Property);
-        assertNull(filter.filterProperty(test2Property, context2));
-        assertNull(filter.filterProperty(test3Property, context3));
+        assertThat(filter.filterProperty(test1Property, context1)).isEqualTo(test1Property);
+        assertThat(filter.filterProperty(test2Property, context2)).isNull();
+        assertThat(filter.filterProperty(test3Property, context3)).isNull();
         filter.clearFilters();
-        assertEquals(filter.filterProperty(test1Property, context1), test1Property);
-        assertEquals(filter.filterProperty(test2Property, context2), test2Property);
-        assertEquals(filter.filterProperty(test3Property, context3), test3Property);
+        assertThat(filter.filterProperty(test1Property, context1)).isEqualTo(test1Property);
+        assertThat(filter.filterProperty(test2Property, context2)).isEqualTo(test2Property);
+        assertThat(filter.filterProperty(test3Property, context3)).isEqualTo(test3Property);
     }
 
     @Test
@@ -107,10 +107,10 @@ public class ProgrammableFilterTest {
         FilterContext context1 = new FilterContext(test1Property, map, context);
         FilterContext context2 = new FilterContext(test2Property, map, context);
         FilterContext context3 = new FilterContext(test3Property, map, context);
-        assertEquals(filter.filterProperty(test1Property, context1), test1Property);
-        assertEquals(filter.filterProperty(test2Property, context2), test2Property);
-        assertEquals(filter.filterProperty(test3Property, context3), test3Property);
-        assertEquals(filter.filterProperty(test3Property, context1), test3Property);
+        assertThat(filter.filterProperty(test1Property, context1)).isEqualTo(test1Property);
+        assertThat(filter.filterProperty(test2Property, context2)).isEqualTo(test2Property);
+        assertThat(filter.filterProperty(test3Property, context3)).isEqualTo(test3Property);
+        assertThat(filter.filterProperty(test3Property, context1)).isEqualTo(test3Property);
     }
 
     @Test
@@ -122,40 +122,40 @@ public class ProgrammableFilterTest {
         FilterContext context1 = new FilterContext(test1Property, context);
         FilterContext context2 = new FilterContext(test2Property, context);
         FilterContext context3 = new FilterContext(test3Property, context);
-        assertEquals(filter.filterProperty(test1Property, context1), test1Property);
-        assertEquals(filter.filterProperty(test2Property, context2), test2Property);
-        assertEquals(filter.filterProperty(test3Property, context3), test3Property);
+        assertThat(filter.filterProperty(test1Property, context1)).isEqualTo(test1Property);
+        assertThat(filter.filterProperty(test2Property, context2)).isEqualTo(test2Property);
+        assertThat(filter.filterProperty(test3Property, context3)).isEqualTo(test3Property);
         filter.setFilters(Arrays.asList(new PropertyFilter[]{regexFilter}));
-        assertEquals(filter.filterProperty(test1Property, context1), test1Property);
-        assertNull(filter.filterProperty(test2Property, context2));
-        assertNull(filter.filterProperty(test3Property, context3));
+        assertThat(filter.filterProperty(test1Property, context1)).isEqualTo(test1Property);
+        assertThat(filter.filterProperty(test2Property, context2)).isNull();
+        assertThat(filter.filterProperty(test3Property, context3)).isNull();
     }
 
     @Test
     public void testGetFilters() throws Exception {
         ThreadFilterContext filter = new ThreadFilterContext();
-        assertNotNull(filter.getFilters());
-        assertTrue(filter.getFilters().isEmpty());
+        assertThat(filter.getFilters()).isNotNull();
+        assertThat(filter.getFilters().isEmpty()).isTrue();
         RegexPropertyFilter regexFilter = new RegexPropertyFilter();
         regexFilter.setIncludes("test\\..*");
         filter.addFilter(regexFilter);
-        assertNotNull(filter.getFilters());
-        assertFalse(filter.getFilters().isEmpty());
-        assertEquals(1, filter.getFilters().size());
-        assertEquals(regexFilter, filter.getFilters().get(0));
+        assertThat(filter.getFilters()).isNotNull();
+        assertThat(filter.getFilters().isEmpty()).isFalse();
+        assertThat(filter.getFilters()).hasSize(1);
+        assertThat(regexFilter).isEqualTo(filter.getFilters().get(0));
     }
 
     @Test
     public void testToString() throws Exception {
         ThreadFilterContext filter = new ThreadFilterContext();
-        assertFalse(filter.toString().contains("test\\..*"));
-        assertTrue(filter.toString().contains("ProgrammableFilter"));
-        assertFalse(filter.toString().contains("RegexPropertyFilter"));
+        assertThat(filter.toString().contains("test\\..*")).isFalse();
+        assertThat(filter.toString().contains("ProgrammableFilter")).isTrue();
+        assertThat(filter.toString().contains("RegexPropertyFilter")).isFalse();
         RegexPropertyFilter regexFilter = new RegexPropertyFilter();
         regexFilter.setIncludes("test\\..*");
         filter.addFilter(regexFilter);
-        assertTrue(filter.toString().contains("test\\..*"));
-        assertTrue(filter.toString().contains("ProgrammableFilter"));
-        assertTrue(filter.toString().contains("RegexPropertyFilter"));
+        assertThat(filter.toString().contains("test\\..*")).isTrue();
+        assertThat(filter.toString().contains("ProgrammableFilter")).isTrue();
+        assertThat(filter.toString().contains("RegexPropertyFilter")).isTrue();
     }
 }

--- a/modules/formats/base/pom.xml
+++ b/modules/formats/base/pom.xml
@@ -70,6 +70,10 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/modules/formats/base/pom.xml
+++ b/modules/formats/base/pom.xml
@@ -62,10 +62,6 @@ under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/formats/base/src/test/java/org/apache/tamaya/format/ConfigurationFormatsTest.java
+++ b/modules/formats/base/src/test/java/org/apache/tamaya/format/ConfigurationFormatsTest.java
@@ -23,9 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link org.apache.tamaya.format.ConfigurationFormats}.
@@ -35,18 +33,18 @@ public class ConfigurationFormatsTest {
     @org.junit.Test
     public void testGetFormats() throws Exception {
         List<ConfigurationFormat> formats = ConfigurationFormats.getInstance().getFormats();
-        assertNotNull(formats);
-        assertEquals(formats.size(), 3);
+        assertThat(formats).isNotNull();
+        assertThat(formats).hasSize(3);
     }
 
     @org.junit.Test
     public void testReadConfigurationData() throws Exception {
         List<ConfigurationFormat> formats = ConfigurationFormats.getInstance().getFormats(getClass().getResource("/Test.ini"));
-        assertNotNull(formats);
-        assertEquals(formats.size(), 1);
+        assertThat(formats).isNotNull();
+        assertThat(formats).hasSize(1);
         formats = ConfigurationFormats.getInstance().getFormats(getClass().getResource("/Test.properties"));
-        assertNotNull(formats);
-        assertEquals(formats.size(), 1);
+        assertThat(formats).isNotNull();
+        assertThat(formats).hasSize(1);
 
     }
 
@@ -54,9 +52,9 @@ public class ConfigurationFormatsTest {
     public void testReadConfigurationData_URL() throws Exception {
         ConfigurationData data = ConfigurationFormats.getInstance().readConfigurationData(
                 getClass().getResource("/Test.ini"));
-        assertNotNull(data);
+        assertThat(data).isNotNull();
         data = ConfigurationFormats.getInstance().readConfigurationData(getClass().getResource("/Test.properties"));
-        assertNotNull(data);
+        assertThat(data).isNotNull();
     }
 
     @org.junit.Test
@@ -64,7 +62,7 @@ public class ConfigurationFormatsTest {
         ConfigurationData data = ConfigurationFormats.getInstance().readConfigurationData(
                 getClass().getResource("/Test.ini"),
                 ConfigurationFormats.getInstance().getFormats("ini"));
-        assertNotNull(data);
+        assertThat(data).isNotNull();
     }
 
     @org.junit.Test
@@ -74,7 +72,7 @@ public class ConfigurationFormatsTest {
         ConfigurationData data = ConfigurationFormats.getInstance().readConfigurationData(
                 getClass().getResource("/Test.ini"),
                 formats);
-        assertNotNull(data);
+        assertThat(data).isNotNull();
     }
 
     @org.junit.Test
@@ -86,8 +84,8 @@ public class ConfigurationFormatsTest {
         Collection<ConfigurationData> data = ConfigurationFormats.getInstance().readConfigurationData(
                 urls,
                 formats);
-        assertNotNull(data);
-        assertTrue(data.size()==1);
+        assertThat(data).isNotNull();
+        assertThat(data).hasSize(1);
     }
 
     @org.junit.Test
@@ -97,8 +95,8 @@ public class ConfigurationFormatsTest {
         Collection<ConfigurationData> data = ConfigurationFormats.getInstance().readConfigurationData(
                 urls,
                 ConfigurationFormats.getInstance().getFormats("ini").get(0));
-        assertNotNull(data);
-        assertTrue(data.size()==1);
+        assertThat(data).isNotNull();
+        assertThat(data).hasSize(1);
     }
 
     @org.junit.Test
@@ -107,7 +105,7 @@ public class ConfigurationFormatsTest {
                 "Test.ini",
                 getClass().getResource("/Test.ini").openStream(),
                 ConfigurationFormats.getInstance().getFormats("ini"));
-        assertNotNull(data);
+        assertThat(data).isNotNull();
     }
 
     @org.junit.Test
@@ -118,7 +116,7 @@ public class ConfigurationFormatsTest {
                 "Test.ini",
                 getClass().getResource("/Test.ini").openStream(),
                 formats);
-        assertNotNull(data);
+        assertThat(data).isNotNull();
     }
 
     @org.junit.Test
@@ -127,7 +125,7 @@ public class ConfigurationFormatsTest {
         ConfigurationData data = ConfigurationFormats.getInstance().readConfigurationData(
                 getClass().getResource("/Test.ini"),
                 formats.toArray(new ConfigurationFormat[formats.size()]));
-        assertNotNull(data);
+        assertThat(data).isNotNull();
         System.out.println(data);
     }
 }

--- a/modules/formats/base/src/test/java/org/apache/tamaya/format/FormatPropertySourceProviderTest.java
+++ b/modules/formats/base/src/test/java/org/apache/tamaya/format/FormatPropertySourceProviderTest.java
@@ -24,7 +24,8 @@ import java.util.Collection;
 import org.apache.tamaya.spi.PropertySource;
 import org.apache.tamaya.spi.PropertySourceProvider;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FormatPropertySourceProviderTest
         extends BaseFormatPropertySourceProvider {
@@ -36,8 +37,7 @@ public class FormatPropertySourceProviderTest
     public void getPropertySourcesTest() {
         PropertySourceProvider provider = new FormatPropertySourceProviderTest();
         Collection<PropertySource> sources = provider.getPropertySources();
-        
-        assertEquals(2, sources.size());
+        assertThat(sources).hasSize(2);
     }
 
     @Override

--- a/modules/formats/base/src/test/java/org/apache/tamaya/format/InputStreamFactoryTest.java
+++ b/modules/formats/base/src/test/java/org/apache/tamaya/format/InputStreamFactoryTest.java
@@ -24,9 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -61,7 +59,7 @@ public class InputStreamFactoryTest {
         byte[] byteArray = new byte[4];
         for (int i = 0; i < 100; i++) {
             InputStream is = closer.createInputStream();
-            assertThat(is.read(byteArray), equalTo(4));
+            assertThat(is.read(byteArray)).isEqualTo(4);
         }
     }
 
@@ -72,7 +70,7 @@ public class InputStreamFactoryTest {
         InputStreamFactory closer = new InputStreamFactory(stream);
         for (int i = 0; i < 100; i++) {
             InputStream is = closer.createInputStream();
-            assertThat(is.skip(2L), equalTo(2L));
+            assertThat(is.skip(2L)).isEqualTo(2L);
         }
     }
 
@@ -83,7 +81,7 @@ public class InputStreamFactoryTest {
         InputStreamFactory closer = new InputStreamFactory(stream);
         for (int i = 0; i < 100; i++) {
             InputStream is = closer.createInputStream();
-            assertThat(is.available(), equalTo(4));
+            assertThat(is.available()).isEqualTo(4);
         }
     }
 
@@ -124,7 +122,7 @@ public class InputStreamFactoryTest {
         InputStreamFactory closer = new InputStreamFactory(stream);
         for (int i = 0; i < 100; i++) {
             InputStream is = closer.createInputStream();
-            assertThat(is.markSupported(), is(true));
+            assertThat(is.markSupported()).isTrue();
         }
     }
 
@@ -134,10 +132,10 @@ public class InputStreamFactoryTest {
         InputStreamFactory closer = new InputStreamFactory(stream);
         for (int i = 0; i < 100; i++) {
             InputStream is = closer.createInputStream();
-            assertThat(is.read(), equalTo(1));
-            assertThat(is.read(), equalTo(2));
-            assertThat(is.read(), equalTo(3));
-            assertThat(is.read(), equalTo(4));
+            assertThat(is.read()).isEqualTo(1);
+            assertThat(is.read()).isEqualTo(2);
+            assertThat(is.read()).isEqualTo(3);
+            assertThat(is.read()).isEqualTo(4);
         }
     }
 

--- a/modules/formats/base/src/test/java/org/apache/tamaya/format/MappedConfigurationDataPropertySourceTest.java
+++ b/modules/formats/base/src/test/java/org/apache/tamaya/format/MappedConfigurationDataPropertySourceTest.java
@@ -22,10 +22,6 @@ import org.apache.tamaya.format.formats.PropertiesFormat;
 import org.apache.tamaya.spi.PropertySource;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 /**
  * Tests for {@link MappedConfigurationDataPropertySource}.
  */

--- a/modules/formats/json/pom.xml
+++ b/modules/formats/json/pom.xml
@@ -95,10 +95,6 @@ under the License.
             <artifactId>arquillian-junit-container</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/modules/formats/json/src/test/java/org/apache/tamaya/json/CommonJSONTestCaseCollection.java
+++ b/modules/formats/json/src/test/java/org/apache/tamaya/json/CommonJSONTestCaseCollection.java
@@ -18,22 +18,15 @@
  */
 package org.apache.tamaya.json;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.net.URL;
 
 import org.apache.tamaya.spi.PropertySource;
 import org.apache.tamaya.spi.PropertyValue;
 import org.apache.tamaya.spisupport.PropertySourceComparator;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Class with a collection of common test cases each JSON processing
@@ -48,14 +41,14 @@ public abstract class CommonJSONTestCaseCollection {
         URL configURL = CommonJSONTestCaseCollection.class
              .getResource("/configs/valid/cyrillic.json");
 
-        assertThat(configURL, Matchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         PropertySource propertySource = getPropertiesFrom(configURL);
 
-        assertThat(propertySource.get("name"), Matchers.notNullValue());
-        assertThat(propertySource.get("name").getValue(), equalTo("\u041e\u043b\u0438\u0432\u0435\u0440"));
-        assertThat(propertySource.get("\u0444\u0430\u043c\u0438\u043b\u0438\u044f"), Matchers.notNullValue());
-        assertThat(propertySource.get("\u0444\u0430\u043c\u0438\u043b\u0438\u044f").getValue(), Matchers.equalTo("Fischer"));
+        assertThat(propertySource.get("name")).isNotNull();
+        assertThat(propertySource.get("name").getValue()).isEqualTo("\u041e\u043b\u0438\u0432\u0435\u0440");
+        assertThat(propertySource.get("\u0444\u0430\u043c\u0438\u043b\u0438\u044f")).isNotNull();
+        assertThat(propertySource.get("\u0444\u0430\u043c\u0438\u043b\u0438\u044f").getValue()).isEqualTo("Fischer");
     }
 
     @Test
@@ -63,13 +56,13 @@ public abstract class CommonJSONTestCaseCollection {
         URL configURL = CommonJSONTestCaseCollection.class
                 .getResource("/configs/valid/kanji.json");
 
-        assertThat(configURL, Matchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         PropertySource propertySource = getPropertiesFrom(configURL);
 
-        assertThat(propertySource.get("onamae"), Matchers.notNullValue());
+        assertThat(propertySource.get("onamae")).isNotNull();
         // 霊屋 = Tamaya
-        assertThat(propertySource.get("onamae").getValue(), equalTo("\u970a\u5c4b"));
+        assertThat(propertySource.get("onamae").getValue()).isEqualTo("\u970a\u5c4b");
     }
 
     @Test
@@ -77,24 +70,24 @@ public abstract class CommonJSONTestCaseCollection {
         URL configURL = CommonJSONTestCaseCollection.class
                 .getResource("/configs/valid/simple-nested-string-only-config-1.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         PropertySource properties = getPropertiesFrom(configURL);
 
         System.out.println("simple-nested-string-only-config-1.json -> " + properties.getProperties().values());
 
-        assertTrue(properties.getProperties().keySet().size()>=5);
+        assertThat(properties.getProperties().keySet().size() >= 5).isTrue();
 
         PropertyValue keyB = properties.get("b");
         PropertyValue keyDO = properties.get("d.o");
         PropertyValue keyDP = properties.get("d.p");
 
-        assertThat(keyB, notNullValue());
-        assertThat(keyB.getValue(), equalTo("B"));
-        assertThat(keyDO, notNullValue());
-        assertThat(keyDO.getValue(), equalTo("O"));
-        assertThat(keyDP, Matchers.notNullValue());
-        assertThat(keyDP.getValue(), is("P"));
+        assertThat(keyB).isNotNull();
+        assertThat(keyB.getValue()).isEqualTo("B");
+        assertThat(keyDO).isNotNull();
+        assertThat(keyDO.getValue()).isEqualTo("O");
+        assertThat(keyDP).isNotNull();
+        assertThat(keyDP.getValue()).isEqualTo("P");
     }
 
     @Test
@@ -103,32 +96,32 @@ public abstract class CommonJSONTestCaseCollection {
         URL configURL = CommonJSONTestCaseCollection.class
                 .getResource("/configs/valid/simple-nested-string-only-config-2.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         PropertySource properties = getPropertiesFrom(configURL);
 
-        assertTrue(properties.getProperties().keySet().size()>=4);
+        assertThat(properties.getProperties().keySet().size() >= 4).isTrue();
 
         PropertyValue keyA = properties.get("a");
         PropertyValue keyDO = properties.get("b.o");
         PropertyValue keyDP = properties.get("b.p");
         PropertyValue keyC = properties.get("c");
 
-        assertThat(keyA, notNullValue());
-        assertThat(keyA.getValue(), is("A"));
-        assertThat(keyC, notNullValue());
-        assertThat(keyC.getValue(), equalTo("C"));
-        assertThat(keyDO, notNullValue());
-        assertThat(keyDO.getValue(), equalTo("O"));
-        assertThat(keyDP, notNullValue());
-        assertThat(keyDP.getValue(), is("P"));
+        assertThat(keyA).isNotNull();
+        assertThat(keyA.getValue()).isEqualTo("A");
+        assertThat(keyC).isNotNull();
+        assertThat(keyC.getValue()).isEqualTo("C");
+        assertThat(keyDO).isNotNull();
+        assertThat(keyDO.getValue()).isEqualTo("O");
+        assertThat(keyDP).isNotNull();
+        assertThat(keyDP.getValue()).isEqualTo("P");
     }
 
     @Test
     public void canHandleIllegalJSONFileWhichContainsAnArray() throws Exception {
         URL configURL = CommonJSONTestCaseCollection.class.getResource("/configs/invalid/with-array.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         getPropertiesFrom(configURL).getProperties();
     }
@@ -137,7 +130,7 @@ public abstract class CommonJSONTestCaseCollection {
     public void canHandleIllegalJSONFileConsistingOfOneOpeningBracket() throws Exception {
         URL configURL = CommonJSONTestCaseCollection.class.getResource("/configs/invalid/only-opening-bracket.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         getPropertiesFrom(configURL).getProperties();
     }
@@ -146,7 +139,7 @@ public abstract class CommonJSONTestCaseCollection {
     public void canHandleIllegalJSONFileWhichIsEmpty() throws Exception {
         URL configURL = CommonJSONTestCaseCollection.class.getResource("/configs/invalid/empty-file.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         getPropertiesFrom(configURL).getProperties();
     }
@@ -155,40 +148,40 @@ public abstract class CommonJSONTestCaseCollection {
     public void priorityInConfigFileOverwriteExplicitlyGivenPriority() throws Exception {
         URL configURL = CommonJSONTestCaseCollection.class.getResource("/configs/valid/with-explicit-priority.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         PropertySource properties = getPropertiesFrom(configURL);
 
-        assertThat(PropertySourceComparator.getOrdinal(properties), is(16784));
+        assertThat(PropertySourceComparator.getOrdinal(properties)).isEqualTo(16784);
     }
 
     @Test
     public void canReadFlatStringOnlyJSONConfigFile() throws Exception {
         URL configURL = CommonJSONTestCaseCollection.class.getResource("/configs/valid/simple-flat-string-only-config.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         PropertySource properties = getPropertiesFrom(configURL);
 
-        assertEquals(3, properties.getProperties().size());
+        assertThat(3).isEqualTo(properties.getProperties().size());
 
         PropertyValue keyA = properties.get("a");
         PropertyValue keyB = properties.get("b");
         PropertyValue keyC = properties.get("c");
 
-        assertThat(keyA, notNullValue());
-        assertThat(keyA.getValue(), equalTo("A"));
-        assertThat(keyB, notNullValue());
-        assertThat(keyB.getValue(), is("B"));
-        assertThat(keyC, notNullValue());
-        assertThat(keyC.getValue(), is("C"));
+        assertThat(keyA).isNotNull();
+        assertThat(keyA.getValue()).isEqualTo("A");
+        assertThat(keyB).isNotNull();
+        assertThat(keyB.getValue()).isEqualTo("B");
+        assertThat(keyC).isNotNull();
+        assertThat(keyC.getValue()).isEqualTo("C");
     }
 
     @Test(expected = IOException.class)
     public void emptyJSONFileResultsInConfigException() throws Exception {
         URL configURL = CommonJSONTestCaseCollection.class.getResource("/configs/invalid/empty-file.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         PropertySource properties = getPropertiesFrom(configURL);
 
@@ -199,10 +192,10 @@ public abstract class CommonJSONTestCaseCollection {
     public void canHandleEmptyJSONObject() throws Exception {
         URL configURL = CommonJSONTestCaseCollection.class.getResource("/configs/valid/empty-object-config.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         PropertySource properties = getPropertiesFrom(configURL);
 
-        assertTrue(properties.getProperties().keySet().size()>=0);
+        assertThat(properties.getProperties().keySet().size() >= 0).isTrue();
     }
 }

--- a/modules/formats/json/src/test/java/org/apache/tamaya/json/JSONFormatIT.java
+++ b/modules/formats/json/src/test/java/org/apache/tamaya/json/JSONFormatIT.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for {@link JSONFormat}.
@@ -44,6 +43,6 @@ public class JSONFormatIT {
                 break;
             }
         }
-        assertThat(format, notNullValue());
+        assertThat(format).isNotNull();
     }
 }

--- a/modules/formats/json/src/test/java/org/apache/tamaya/json/JSONFormatTest.java
+++ b/modules/formats/json/src/test/java/org/apache/tamaya/json/JSONFormatTest.java
@@ -27,8 +27,7 @@ import org.junit.Test;
 import java.io.InputStream;
 import java.net.URL;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JSONFormatTest extends CommonJSONTestCaseCollection {
     private final JSONFormat format = new JSONFormat();
@@ -42,27 +41,27 @@ public class JSONFormatTest extends CommonJSONTestCaseCollection {
     public void aNonJSONFileBasedURLIsNotAccepted() throws Exception {
         URL url = new URL("file:///etc/service/conf.conf");
 
-        assertThat(format.accepts(url), is(false));
+        assertThat(format.accepts(url)).isFalse();
     }
 
     @Test
     public void aJSONFileBasedURLIsAccepted() throws Exception {
         URL url = new URL("file:///etc/service/conf.json");
 
-        assertThat(format.accepts(url), is(true));
+        assertThat(format.accepts(url)).isTrue();
     }
 
     @Test
     public void aHTTPBasedURLIsNotAccepted() throws Exception {
         URL url = new URL("http://nowhere.somewhere/conf.json");
-        assertThat(format.accepts(url), is(true));
+        assertThat(format.accepts(url)).isTrue();
     }
 
     @Test
     public void aFTPBasedURLIsNotAccepted() throws Exception {
         URL url = new URL("ftp://nowhere.somewhere/a/b/c/d/conf.json");
 
-        assertThat(format.accepts(url), is(true));
+        assertThat(format.accepts(url)).isTrue();
     }
 
     @Override

--- a/modules/formats/json/src/test/java/org/apache/tamaya/json/JSONPropertySourceTest.java
+++ b/modules/formats/json/src/test/java/org/apache/tamaya/json/JSONPropertySourceTest.java
@@ -18,14 +18,12 @@
  */
 package org.apache.tamaya.json;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-
 import java.net.URL;
 
 import org.apache.tamaya.spi.PropertySource;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JSONPropertySourceTest extends CommonJSONTestCaseCollection {
 
@@ -33,17 +31,17 @@ public class JSONPropertySourceTest extends CommonJSONTestCaseCollection {
     public void tamayaOrdinalKeywordIsNotPropagatedAsNormalProperty() throws Exception {
         URL configURL = JSONPropertySourceTest.class.getResource("/configs/valid/with-explicit-priority.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         JSONPropertySource source = new JSONPropertySource(configURL, 4);
-        assertEquals(source.getOrdinal(), 16784);
+        assertThat(source.getOrdinal()).isEqualTo(16784);
     }
-    
+
     @Test
     public void testAcceptJsonArrays() throws Exception {
         URL configURL = JSONPropertySourceTest.class.getResource("/configs/invalid/array.json");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         new JSONPropertySource(configURL);
     }

--- a/modules/formats/json/src/test/java/org/apache/tamaya/json/JSONVisitorTest.java
+++ b/modules/formats/json/src/test/java/org/apache/tamaya/json/JSONVisitorTest.java
@@ -21,8 +21,7 @@ package org.apache.tamaya.json;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -52,7 +51,7 @@ public class JSONVisitorTest {
 
 		ObjectValue ov = data.toObjectValue();
 		assertThat(ov.getValues().size() == 6);
-		assertEquals(data.getSize(), 6);
+		assertThat(data.getSize()).isEqualTo(6);
 		assertThat(data.toMap()).containsKeys("key.sub", "anotherKey", "notAnotherKey", "number", "null");
 		assertThat(data.toMap()).containsEntry("key.sub", "createValue");
 		assertThat(data.toMap()).containsEntry("null", null);

--- a/modules/formats/json/src/test/java/org/apache/tamaya/json/PathBasedJsonPropertySourceProviderTest.java
+++ b/modules/formats/json/src/test/java/org/apache/tamaya/json/PathBasedJsonPropertySourceProviderTest.java
@@ -20,8 +20,7 @@ package org.apache.tamaya.json;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link PathBasedJsonPropertySourceProvider}.
@@ -33,8 +32,8 @@ public class PathBasedJsonPropertySourceProviderTest {
         PathBasedJsonPropertySourceProvider provider = new PathBasedJsonPropertySourceProvider(
                 "configs/valid/*.json"
         );
-        assertNotNull(provider.getPropertySources());
-        assertEquals(7, provider.getPropertySources().size());
+        assertThat(provider.getPropertySources()).isNotNull();
+        assertThat(provider.getPropertySources()).hasSize(7);
     }
 
     @Test
@@ -42,8 +41,8 @@ public class PathBasedJsonPropertySourceProviderTest {
         PathBasedJsonPropertySourceProvider provider = new PathBasedJsonPropertySourceProvider(
                 "configs/valid/cyril*.json"
         );
-        assertNotNull(provider.getPropertySources());
-        assertEquals(1, provider.getPropertySources().size());
+        assertThat(provider.getPropertySources()).isNotNull();
+        assertThat(provider.getPropertySources()).hasSize(1);
     }
 
     @Test
@@ -51,8 +50,8 @@ public class PathBasedJsonPropertySourceProviderTest {
         PathBasedJsonPropertySourceProvider provider = new PathBasedJsonPropertySourceProvider(
                 "configs/valid/simple-*.json"
         );
-        assertNotNull(provider.getPropertySources());
-        assertEquals(3, provider.getPropertySources().size());
+        assertThat(provider.getPropertySources()).isNotNull();
+        assertThat(provider.getPropertySources()).hasSize(3);
     }
 
     @Test
@@ -60,7 +59,7 @@ public class PathBasedJsonPropertySourceProviderTest {
         PathBasedJsonPropertySourceProvider provider = new PathBasedJsonPropertySourceProvider(
                 "configs/valid/foo*.json", "configs/valid/*.JSON"
         );
-        assertNotNull(provider.getPropertySources());
-        assertEquals(0, provider.getPropertySources().size());
+        assertThat(provider.getPropertySources()).isNotNull();
+        assertThat(provider.getPropertySources()).hasSize(0);
     }
 }

--- a/modules/formats/yaml/pom.xml
+++ b/modules/formats/yaml/pom.xml
@@ -71,6 +71,10 @@ under the License.
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/formats/yaml/pom.xml
+++ b/modules/formats/yaml/pom.xml
@@ -68,10 +68,6 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/modules/formats/yaml/src/test/java/org/apache/tamaya/yaml/PathBasedYamlPropertySourceProviderTest.java
+++ b/modules/formats/yaml/src/test/java/org/apache/tamaya/yaml/PathBasedYamlPropertySourceProviderTest.java
@@ -20,7 +20,7 @@ package org.apache.tamaya.yaml;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link PathBasedYamlPropertySourceProvider}.
@@ -32,8 +32,8 @@ public class PathBasedYamlPropertySourceProviderTest {
         PathBasedYamlPropertySourceProvider provider = new PathBasedYamlPropertySourceProvider(
                 "configs/valid/*.yaml"
         );
-        assertNotNull(provider.getPropertySources());
-        assertEquals(3, provider.getPropertySources().size());
+        assertThat(provider.getPropertySources()).isNotNull();
+        assertThat(provider.getPropertySources()).hasSize(3);
     }
 
     @Test
@@ -41,8 +41,8 @@ public class PathBasedYamlPropertySourceProviderTest {
         PathBasedYamlPropertySourceProvider provider = new PathBasedYamlPropertySourceProvider(
                 "configs/valid/conta*.yaml"
         );
-        assertNotNull(provider.getPropertySources());
-        assertEquals(1, provider.getPropertySources().size());
+        assertThat(provider.getPropertySources()).isNotNull();
+        assertThat(provider.getPropertySources()).hasSize(1);
     }
 
     @Test
@@ -50,8 +50,8 @@ public class PathBasedYamlPropertySourceProviderTest {
         PathBasedYamlPropertySourceProvider provider = new PathBasedYamlPropertySourceProvider(
                 "configs/valid/test*.yaml"
         );
-        assertNotNull(provider.getPropertySources());
-        assertEquals(2, provider.getPropertySources().size());
+        assertThat(provider.getPropertySources()).isNotNull();
+        assertThat(provider.getPropertySources()).hasSize(2);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class PathBasedYamlPropertySourceProviderTest {
         PathBasedYamlPropertySourceProvider provider = new PathBasedYamlPropertySourceProvider(
                 "configs/valid/foo*.yaml", "configs/valid/*.yml"
         );
-        assertNotNull(provider.getPropertySources());
-        assertEquals(0, provider.getPropertySources().size());
+        assertThat(provider.getPropertySources()).isNotNull();
+        assertThat(provider.getPropertySources()).hasSize(0);
     }
 }

--- a/modules/formats/yaml/src/test/java/org/apache/tamaya/yaml/YAMLFormatTest.java
+++ b/modules/formats/yaml/src/test/java/org/apache/tamaya/yaml/YAMLFormatTest.java
@@ -28,37 +28,37 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class YAMLFormatTest {
     private final YAMLFormat format = new YAMLFormat();
 
     @Test
     public void testAcceptURL() throws MalformedURLException {
-        assertTrue(format.accepts(new URL("http://127.0.0.1/anyfile.yaml")));
+        assertThat(format.accepts(new URL("http://127.0.0.1/anyfile.yaml"))).isTrue();
     }
 
     @Test
     public void testAcceptURL_BC1() throws MalformedURLException {
-        assertFalse(format.accepts(new URL("http://127.0.0.1/anyfile.YAML")));
+        assertThat(format.accepts(new URL("http://127.0.0.1/anyfile.YAML"))).isFalse();
     }
 
     @Test(expected = NullPointerException.class)
     public void testAcceptURL_BC2() throws MalformedURLException {
-        assertFalse(format.accepts(null));
+        assertThat(format.accepts(null)).isFalse();
     }
 
     @Test
     public void testAcceptURL_BC3() throws MalformedURLException {
-        assertFalse(format.accepts(new URL("http://127.0.0.1/anyfile.docx")));
+        assertThat(format.accepts(new URL("http://127.0.0.1/anyfile.docx"))).isFalse();
     }
 
     @Test
     public void testRead() throws IOException {
         URL configURL = YAMLPropertySourceTest.class.getResource("/configs/valid/contact.yaml");
-        assertTrue(format.accepts(configURL));
+        assertThat(format.accepts(configURL)).isTrue();
         ConfigurationData data = format.readConfiguration(configURL.toString(), configURL.openStream());
-        assertNotNull(data);
+        assertThat(data).isNotNull();
         for(Map.Entry<String,String> en:data.getData().get(0).toMap().entrySet()) {
             System.out.println(en.getKey() + " -> " + en.getValue());
         }

--- a/modules/formats/yaml/src/test/java/org/apache/tamaya/yaml/YAMLPropertySourceTest.java
+++ b/modules/formats/yaml/src/test/java/org/apache/tamaya/yaml/YAMLPropertySourceTest.java
@@ -18,13 +18,11 @@
  */
 package org.apache.tamaya.yaml;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.net.URL;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class YAMLPropertySourceTest {
 
@@ -32,21 +30,19 @@ public class YAMLPropertySourceTest {
     public void testYamlWithOrdinal() throws Exception {
         URL configURL = YAMLPropertySourceTest.class.getResource("/configs/valid/test-with-prio.yaml");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         YAMLPropertySource source = new YAMLPropertySource(configURL, 4);
-        assertEquals(source.getOrdinal(), 16784);
+        assertThat(source.getOrdinal()).isEqualTo(16784);
     }
-    
+
     @Test
     public void testYamlDefaultOrdinal() throws Exception {
         URL configURL = YAMLPropertySourceTest.class.getResource("/configs/valid/test.yaml");
 
-        assertThat(configURL, CoreMatchers.notNullValue());
+        assertThat(configURL).isNotNull();
 
         YAMLPropertySource source = new YAMLPropertySource(configURL, 4);
-        assertEquals(source.getOrdinal(), 4);
+        assertThat(source.getOrdinal()).isEqualTo(4);
     }
-
-
 }

--- a/modules/functions/pom.xml
+++ b/modules/functions/pom.xml
@@ -74,11 +74,6 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/functions/src/test/java/org/apache/tamaya/functions/ConfigurationFunctionsTest.java
+++ b/modules/functions/src/test/java/org/apache/tamaya/functions/ConfigurationFunctionsTest.java
@@ -28,7 +28,7 @@ import java.io.PrintStream;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by Anatole on 01.10.2015.
@@ -146,9 +146,9 @@ public class ConfigurationFunctionsTest {
     @Test
     public void testEmptyConfiguration() throws Exception {
         Configuration ps = ConfigurationFunctions.emptyConfiguration();
-        assertNotNull(ps);
-        assertNotNull(ps.getProperties());
-        assertTrue(ps.getProperties().isEmpty());
+        assertThat(ps).isNotNull();
+        assertThat(ps.getProperties()).isNotNull();
+        assertThat(ps.getProperties().isEmpty()).isTrue();
     }
 
 

--- a/modules/functions/src/test/java/org/apache/tamaya/functions/PropertySourceFunctionsTest.java
+++ b/modules/functions/src/test/java/org/apache/tamaya/functions/PropertySourceFunctionsTest.java
@@ -28,12 +28,8 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Set;
 
-import static junit.framework.TestCase.assertNotNull;
 import static org.apache.tamaya.functions.PropertySourceFunctions.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.*;
 
 public class PropertySourceFunctionsTest {
 
@@ -358,9 +354,9 @@ public class PropertySourceFunctionsTest {
     @Test
     public void testEmptyPropertySource() throws Exception {
         PropertySource ps = PropertySource.EMPTY;
-        assertNotNull(ps);
-        assertNotNull(ps.getProperties());
-        assertTrue(ps.getProperties().isEmpty());
-        assertEquals(ps.getName(), "<empty>" );
+        assertThat(ps).isNotNull();
+        assertThat(ps.getProperties()).isNotNull();
+        assertThat(ps.getProperties().isEmpty()).isTrue();
+        assertThat(ps.getName()).isEqualTo("<empty>");
     }
 }

--- a/modules/hazelcast/pom.xml
+++ b/modules/hazelcast/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>java-hamcrest</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.tamaya</groupId>
             <artifactId>tamaya-core</artifactId>
             <version>${project.parent.version}</version>

--- a/modules/hazelcast/pom.xml
+++ b/modules/hazelcast/pom.xml
@@ -35,10 +35,6 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/modules/hazelcast/src/test/java/org/apache/tamaya/hazelcast/AbstractHzPropertySourceTest.java
+++ b/modules/hazelcast/src/test/java/org/apache/tamaya/hazelcast/AbstractHzPropertySourceTest.java
@@ -24,11 +24,12 @@ import org.apache.tamaya.spi.PropertyValue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
+import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 03.11.16.
@@ -57,115 +58,115 @@ public class AbstractHzPropertySourceTest {
         map2.flush();
     }
 
-    @org.junit.Test
+    @Test
     public void t01_testGetProperties(){
         hps.setMapReference("config");
         Map<String, PropertyValue> values = hps.getProperties();
-        assertNotNull(values);
-        assertEquals(3, values.size());
-        assertNotNull(values.get("k1"));
-        assertNotNull(values.get("k2"));
-        assertEquals("v1", values.get("k1").getValue());
-        assertEquals("v2", values.get("k2").getValue());
-        assertEquals(hps.getOrdinal(), 2000);
+        assertThat(values).isNotNull();
+        assertThat(3).isEqualTo(values.size());
+        assertThat(values.get("k1")).isNotNull();
+        assertThat(values.get("k2")).isNotNull();
+        assertThat("v1").isEqualTo(values.get("k1").getValue());
+        assertThat("v2").isEqualTo(values.get("k2").getValue());
+        assertThat(hps.getOrdinal()).isEqualTo(2000);
 
         hps.setMapReference("config2");
         Map<String, PropertyValue> values2 = hps.getProperties();
-        assertNotNull(values2);
-        assertEquals(2, values2.size());
-        assertNotNull(values2.get("key1"));
-        assertNotNull(values2.get("key2"));
-        assertEquals("val1", values2.get("key1").getValue());
-        assertEquals("val2", values2.get("key2").getValue());
-        assertEquals(hps.getOrdinal(), 0);
+        assertThat(values2).isNotNull();
+        assertThat(2).isEqualTo(values2.size());
+        assertThat(values2.get("key1")).isNotNull();
+        assertThat(values2.get("key2")).isNotNull();
+        assertThat("val1").isEqualTo(values2.get("key1").getValue());
+        assertThat("val2").isEqualTo(values2.get("key2").getValue());
+        assertThat(hps.getOrdinal()).isEqualTo(0);
 
         hps.setMapReference("foo");
         hps.setDefaultOrdinal(1500);
         Map<String, PropertyValue> values3 = hps.getProperties();
-        assertNotNull(values3);
-        assertEquals(0, values3.size());
-        assertEquals(hps.getOrdinal(), 1500);
+        assertThat(values3).isNotNull();
+        assertThat(values3).hasSize(0);
+        assertThat(hps.getOrdinal()).isEqualTo(1500);
     }
 
-    @org.junit.Test
+    @Test
     public void t02_testGetOrdinal(){
         hps.setMapReference("config");
         hps.setDefaultOrdinal(1500);
-        assertEquals(1500, hps.getDefaultOrdinal());
-        assertEquals(hps.getOrdinal(), 2000);
+        assertThat(1500).isEqualTo(hps.getDefaultOrdinal());
+        assertThat(hps.getOrdinal()).isEqualTo(2000);
 
         hps.setMapReference("config2");
         hps.setDefaultOrdinal(0);
-        assertEquals(0, hps.getDefaultOrdinal());
-        assertEquals(hps.getOrdinal(), 0);
+        assertThat(0).isEqualTo(hps.getDefaultOrdinal());
+        assertThat(hps.getOrdinal()).isEqualTo(0);
 
         hps.setMapReference("foo");
         hps.setDefaultOrdinal(1500);
-        assertEquals(1500, hps.getDefaultOrdinal());
-        assertEquals(hps.getOrdinal(), 1500);
+        assertThat(1500).isEqualTo(hps.getDefaultOrdinal());
+        assertThat(hps.getOrdinal()).isEqualTo(1500);
     }
 
-    @org.junit.Test
+    @Test
     public void t03_tesGet(){
         hps.setMapReference("config");
         PropertyValue val1 = hps.get("k1");
-        assertNotNull(val1);
-        assertEquals("v1", val1.getValue());
+        assertThat(val1).isNotNull();
+        assertThat("v1").isEqualTo(val1.getValue());
         PropertyValue val2 = hps.get("k2");
-        assertNotNull(val2);
-        assertEquals("v2", val2.getValue());
+        assertThat(val2).isNotNull();
+        assertThat("v2").isEqualTo(val2.getValue());
 
         hps.setMapReference("config2");
         val1 = hps.get("key1");
-        assertNotNull(val1);
-        assertEquals("val1", val1.getValue());
+        assertThat(val1).isNotNull();
+        assertThat("val1").isEqualTo(val1.getValue());
         val2 = hps.get("key2");
-        assertNotNull(val2);
-        assertEquals("val2", val2.getValue());
+        assertThat(val2).isNotNull();
+        assertThat("val2").isEqualTo(val2.getValue());
 
         hps.setMapReference("foo");
         val1 = hps.get("key1");
-        assertNull(val1);
+        assertThat(val1).isNull();
         val1 = hps.get("k1");
-        assertNull(val1);
+        assertThat(val1).isNull();
     }
 
-    @org.junit.Test
+    @Test
     public void t03_tesGetMapReference(){
         hps.setMapReference("config");
-        assertEquals("config", hps.getMapReference());
+        assertThat("config").isEqualTo(hps.getMapReference());
 
         hps.setMapReference("config2");
-        assertEquals("config2", hps.getMapReference());
+        assertThat("config2").isEqualTo(hps.getMapReference());
     }
 
-    @org.junit.Test
+    @Test
     public void t03_tesGetSetName(){
         hps.setMapReference("config");
-        assertEquals("config", hps.getMapReference());
-        assertEquals("Hazelcast", hps.getName());
+        assertThat("config").isEqualTo(hps.getMapReference());
+        assertThat("Hazelcast").isEqualTo(hps.getName());
 
         hps.setMapReference("config2");
         hps.setName("foo");
-        assertEquals("config2", hps.getMapReference());
-        assertEquals("foo", hps.getName());
+        assertThat("config2").isEqualTo(hps.getMapReference());
+        assertThat("foo").isEqualTo(hps.getName());
     }
 
-    @org.junit.Test
+    @Test
     public void t04_testCache() throws InterruptedException {
         hps.setCacheTimeout(50L);
-        assertTrue(hps.getValidUntil()>= System.currentTimeMillis());
-        assertEquals(50L, hps.getCachePeriod());
+        assertThat(hps.getValidUntil() >= System.currentTimeMillis()).isTrue();
+        assertThat(50L).isEqualTo(hps.getCachePeriod());
         hps.setMapReference("config");
         hps.setDefaultOrdinal(200);
         Map<String, PropertyValue> values = hps.getProperties();
-        assertNotNull(values);
-        assertEquals(3, values.size());
-        assertNotNull(values.get("k1"));
-        assertNotNull(values.get("k2"));
-        assertEquals("v1", values.get("k1").getValue());
-        assertEquals("v2", values.get("k2").getValue());
-        assertEquals(hps.getOrdinal(), 2000);
+        assertThat(values).isNotNull();
+        assertThat(values).hasSize(3);
+        assertThat(values.get("k1")).isNotNull();
+        assertThat(values.get("k2")).isNotNull();
+        assertThat("v1").isEqualTo(values.get("k1").getValue());
+        assertThat("v2").isEqualTo(values.get("k2").getValue());
+        assertThat(hps.getOrdinal()).isEqualTo(2000);
 
         IMap<Object, Object> map = hz.getMap("config");
         map.put("k3", "v3");
@@ -173,31 +174,31 @@ public class AbstractHzPropertySourceTest {
         map.flush();
 
         // Read from cache
-        assertEquals(50L, hps.getCachePeriod());
-        assertTrue(hps.getValidUntil()>= System.currentTimeMillis());
+        assertThat(50L).isEqualTo(hps.getCachePeriod());
+        assertThat(hps.getValidUntil() >= System.currentTimeMillis()).isTrue();
         values = hps.getProperties();
-        assertNotNull(values);
-        assertEquals(3, values.size());
-        assertNotNull(values.get("k1"));
-        assertNotNull(values.get("k2"));
-        assertEquals("v1", values.get("k1").getValue());
-        assertEquals("v2", values.get("k2").getValue());
-        assertEquals(hps.getOrdinal(), 2000);
+        assertThat(values).isNotNull();
+        assertThat(values).hasSize(3);
+        assertThat(values.get("k1")).isNotNull();
+        assertThat(values.get("k2")).isNotNull();
+        assertThat("v1").isEqualTo(values.get("k1").getValue());
+        assertThat("v2").isEqualTo(values.get("k2").getValue());
+        assertThat(hps.getOrdinal()).isEqualTo(2000);
 
         // Let cache timeout
         Thread.sleep(300L);
 
         // Read updated values
         values = hps.getProperties();
-        assertNotNull(values);
-        assertEquals(3, values.size());
-        assertNotNull(values.get("k1"));
-        assertNotNull(values.get("k2"));
-        assertNotNull(values.get("k3"));
-        assertEquals("v1", values.get("k1").getValue());
-        assertEquals("v2", values.get("k2").getValue());
-        assertEquals("v3", values.get("k3").getValue());
-        assertEquals(hps.getOrdinal(), 200);
+        assertThat(values).isNotNull();
+        assertThat(values).hasSize(3);
+        assertThat(values.get("k1")).isNotNull();
+        assertThat(values.get("k2")).isNotNull();
+        assertThat(values.get("k3")).isNotNull();
+        assertThat("v1").isEqualTo(values.get("k1").getValue());
+        assertThat("v2").isEqualTo(values.get("k2").getValue());
+        assertThat("v3").isEqualTo(values.get("k3").getValue());
+        assertThat(hps.getOrdinal()).isEqualTo(200);
     }
 
     @AfterClass

--- a/modules/hazelcast/src/test/java/org/apache/tamaya/hazelcast/HazelcastPropertySourceTest.java
+++ b/modules/hazelcast/src/test/java/org/apache/tamaya/hazelcast/HazelcastPropertySourceTest.java
@@ -26,11 +26,12 @@ import org.apache.tamaya.spi.PropertyValue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
+import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 03.11.16.
@@ -56,115 +57,115 @@ public class HazelcastPropertySourceTest {
         map2.flush();
     }
 
-    @org.junit.Test
+    @Test
     public void t01_testGetProperties(){
         hps.setMapReference("config3");
         Map<String, PropertyValue> values = hps.getProperties();
-        assertNotNull(values);
-        assertEquals(3, values.size());
-        assertNotNull(values.get("k1"));
-        assertNotNull(values.get("k2"));
-        assertEquals("v1", values.get("k1").getValue());
-        assertEquals("v2", values.get("k2").getValue());
-        assertEquals(hps.getOrdinal(), 2000);
+        assertThat(values).isNotNull();
+        assertThat(3).isEqualTo(values.size());
+        assertThat(values.get("k1")).isNotNull();
+        assertThat(values.get("k2")).isNotNull();
+        assertThat("v1").isEqualTo(values.get("k1").getValue());
+        assertThat("v2").isEqualTo(values.get("k2").getValue());
+        assertThat(hps.getOrdinal()).isEqualTo(2000);
 
         hps.setMapReference("config4");
         Map<String, PropertyValue> values2 = hps.getProperties();
-        assertNotNull(values2);
-        assertEquals(2, values2.size());
-        assertNotNull(values2.get("key1"));
-        assertNotNull(values2.get("key2"));
-        assertEquals("val1", values2.get("key1").getValue());
-        assertEquals("val2", values2.get("key2").getValue());
-        assertEquals(hps.getOrdinal(), 0);
+        assertThat(values2).isNotNull();
+        assertThat(2).isEqualTo(values2.size());
+        assertThat(values2.get("key1")).isNotNull();
+        assertThat(values2.get("key2")).isNotNull();
+        assertThat("val1").isEqualTo(values2.get("key1").getValue());
+        assertThat("val2").isEqualTo(values2.get("key2").getValue());
+        assertThat(hps.getOrdinal()).isEqualTo(0);
 
         hps.setMapReference("bar");
         hps.setDefaultOrdinal(1500);
         Map<String, PropertyValue> values3 = hps.getProperties();
-        assertNotNull(values3);
-        assertEquals(0, values3.size());
-        assertEquals(hps.getOrdinal(), 1500);
+        assertThat(values3).isNotNull();
+        assertThat(0).isEqualTo(values3.size());
+        assertThat(hps.getOrdinal()).isEqualTo(1500);
     }
 
-    @org.junit.Test
+    @Test
     public void t02_testGetOrdinal(){
         hps.setMapReference("config3");
         hps.setDefaultOrdinal(1500);
-        assertEquals(1500, hps.getDefaultOrdinal());
-        assertEquals(hps.getOrdinal(), 2000);
+        assertThat(1500).isEqualTo(hps.getDefaultOrdinal());
+        assertThat(hps.getOrdinal()).isEqualTo(2000);
 
         hps.setMapReference("config4");
         hps.setDefaultOrdinal(0);
-        assertEquals(0, hps.getDefaultOrdinal());
-        assertEquals(hps.getOrdinal(), 0);
+        assertThat(0).isEqualTo(hps.getDefaultOrdinal());
+        assertThat(hps.getOrdinal()).isEqualTo(0);
 
         hps.setMapReference("bar");
         hps.setDefaultOrdinal(1500);
-        assertEquals(1500, hps.getDefaultOrdinal());
-        assertEquals(hps.getOrdinal(), 1500);
+        assertThat(1500).isEqualTo(hps.getDefaultOrdinal());
+        assertThat(hps.getOrdinal()).isEqualTo(1500);
     }
 
-    @org.junit.Test
+    @Test
     public void t03_tesGet(){
         hps.setMapReference("config3");
         PropertyValue val1 = hps.get("k1");
-        assertNotNull(val1);
-        assertEquals("v1", val1.getValue());
+        assertThat(val1).isNotNull();
+        assertThat("v1").isEqualTo(val1.getValue());
         PropertyValue val2 = hps.get("k2");
-        assertNotNull(val2);
-        assertEquals("v2", val2.getValue());
+        assertThat(val2).isNotNull();
+        assertThat("v2").isEqualTo(val2.getValue());
 
         hps.setMapReference("config4");
         val1 = hps.get("key1");
-        assertNotNull(val1);
-        assertEquals("val1", val1.getValue());
+        assertThat(val1).isNotNull();
+        assertThat("val1").isEqualTo(val1.getValue());
         val2 = hps.get("key2");
-        assertNotNull(val2);
-        assertEquals("val2", val2.getValue());
+        assertThat(val2).isNotNull();
+        assertThat("val2").isEqualTo(val2.getValue());
 
         hps.setMapReference("bar");
         val1 = hps.get("key1");
-        assertNull(val1);
+        assertThat(val1).isNull();
         val1 = hps.get("k1");
-        assertNull(val1);
+        assertThat(val1).isNull();
     }
 
-    @org.junit.Test
+    @Test
     public void t03_tesGetMapReference(){
         hps.setMapReference("config3");
-        assertEquals("config3", hps.getMapReference());
+        assertThat("config3").isEqualTo(hps.getMapReference());
 
         hps.setMapReference("config4");
-        assertEquals("config4", hps.getMapReference());
+        assertThat("config4").isEqualTo(hps.getMapReference());
     }
 
-    @org.junit.Test
+    @Test
     public void t03_tesGetSetName(){
         hps.setMapReference("config3");
-        assertEquals("config3", hps.getMapReference());
-        assertEquals("Hazelcast", hps.getName());
+        assertThat("config3").isEqualTo(hps.getMapReference());
+        assertThat("Hazelcast").isEqualTo(hps.getName());
 
         hps.setMapReference("config4");
         hps.setName("bar");
-        assertEquals("config4", hps.getMapReference());
-        assertEquals("bar", hps.getName());
+        assertThat("config4").isEqualTo(hps.getMapReference());
+        assertThat("bar").isEqualTo(hps.getName());
     }
 
-    @org.junit.Test
+    @Test
     public void t04_testCache() throws InterruptedException {
         hps.setCacheTimeout(50L);
-        assertTrue(hps.getValidUntil()>= System.currentTimeMillis());
-        assertEquals(50L, hps.getCachePeriod());
+        assertThat(hps.getValidUntil() >= System.currentTimeMillis()).isTrue();
+        assertThat(50L).isEqualTo(hps.getCachePeriod());
         hps.setMapReference("config3");
         hps.setDefaultOrdinal(200);
         Map<String, PropertyValue> values = hps.getProperties();
-        assertNotNull(values);
-        assertEquals(3, values.size());
-        assertNotNull(values.get("k1"));
-        assertNotNull(values.get("k2"));
-        assertEquals("v1", values.get("k1").getValue());
-        assertEquals("v2", values.get("k2").getValue());
-        assertEquals(hps.getOrdinal(), 2000);
+        assertThat(values).isNotNull();
+        assertThat(3).isEqualTo(values.size());
+        assertThat(values.get("k1")).isNotNull();
+        assertThat(values.get("k2")).isNotNull();
+        assertThat("v1").isEqualTo(values.get("k1").getValue());
+        assertThat("v2").isEqualTo(values.get("k2").getValue());
+        assertThat(hps.getOrdinal()).isEqualTo(2000);
 
         IMap<Object, Object> map = hz.getMap("config3");
         map.put("k3", "v3");
@@ -172,31 +173,31 @@ public class HazelcastPropertySourceTest {
         map.flush();
 
         // Read from cache
-        assertEquals(50L, hps.getCachePeriod());
-        assertTrue(hps.getValidUntil()>= System.currentTimeMillis());
+        assertThat(50L).isEqualTo(hps.getCachePeriod());
+        assertThat(hps.getValidUntil() >= System.currentTimeMillis()).isTrue();
         values = hps.getProperties();
-        assertNotNull(values);
-        assertEquals(3, values.size());
-        assertNotNull(values.get("k1"));
-        assertNotNull(values.get("k2"));
-        assertEquals("v1", values.get("k1").getValue());
-        assertEquals("v2", values.get("k2").getValue());
-        assertEquals(hps.getOrdinal(), 2000);
+        assertThat(values).isNotNull();
+        assertThat(3).isEqualTo(values.size());
+        assertThat(values.get("k1")).isNotNull();
+        assertThat(values.get("k2")).isNotNull();
+        assertThat("v1").isEqualTo(values.get("k1").getValue());
+        assertThat("v2").isEqualTo(values.get("k2").getValue());
+        assertThat(hps.getOrdinal()).isEqualTo(2000);
 
         // Let cache timeout
         Thread.sleep(300L);
 
         // Read updated values
         values = hps.getProperties();
-        assertNotNull(values);
-        assertEquals(3, values.size());
-        assertNotNull(values.get("k1"));
-        assertNotNull(values.get("k2"));
-        assertNotNull(values.get("k3"));
-        assertEquals("v1", values.get("k1").getValue());
-        assertEquals("v2", values.get("k2").getValue());
-        assertEquals("v3", values.get("k3").getValue());
-        assertEquals(hps.getOrdinal(), 200);
+        assertThat(values).isNotNull();
+        assertThat(3).isEqualTo(values.size());
+        assertThat(values.get("k1")).isNotNull();
+        assertThat(values.get("k2")).isNotNull();
+        assertThat(values.get("k3")).isNotNull();
+        assertThat("v1").isEqualTo(values.get("k1").getValue());
+        assertThat("v2").isEqualTo(values.get("k2").getValue());
+        assertThat("v3").isEqualTo(values.get("k3").getValue());
+        assertThat(hps.getOrdinal()).isEqualTo(200);
     }
 
     @AfterClass

--- a/modules/injection/cdi/pom.xml
+++ b/modules/injection/cdi/pom.xml
@@ -86,11 +86,6 @@ under the License.
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.tamaya</groupId>

--- a/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/CDIConfiguredMethodTest.java
+++ b/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/CDIConfiguredMethodTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tamaya.cdi;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -29,8 +28,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 public class CDIConfiguredMethodTest {
@@ -42,7 +40,7 @@ public class CDIConfiguredMethodTest {
 
         CDIConfiguredMethod ccm = new CDIConfiguredMethod(ip, keys);
 
-        assertThat(ccm.getConfiguredKeys(), Matchers.containsInAnyOrder("rate", "weight"));
+        assertThat(ccm.getConfiguredKeys()).contains("rate", "weight");
     }
 
     @Test
@@ -55,7 +53,7 @@ public class CDIConfiguredMethodTest {
 
         CDIConfiguredMethod ccm = new CDIConfiguredMethod(ip, keys);
 
-        assertThat(ccm.getName(), equalTo("getValue"));
+        assertThat(ccm.getName()).isEqualTo("getValue");
     }
 
     @Test
@@ -70,7 +68,7 @@ public class CDIConfiguredMethodTest {
 
         CDIConfiguredMethod ccm = new CDIConfiguredMethod(ip, keys);
 
-        assertThat(ccm.getSignature(), equalTo(expectedSignature));
+        assertThat(ccm.getSignature()).isEqualTo(expectedSignature);
     }
 
     @Test
@@ -85,7 +83,7 @@ public class CDIConfiguredMethodTest {
 
         CDIConfiguredMethod ccm = new CDIConfiguredMethod(ip, keys);
 
-        assertThat(ccm.getSignature(), equalTo(expectedSignature));
+        assertThat(ccm.getSignature()).isEqualTo(expectedSignature);
     }
 
     @Test
@@ -100,7 +98,7 @@ public class CDIConfiguredMethodTest {
 
         CDIConfiguredMethod ccm = new CDIConfiguredMethod(ip, keys);
 
-        assertThat(ccm.getSignature(), equalTo(expectedSignature));
+        assertThat(ccm.getSignature()).isEqualTo(expectedSignature);
     }
 
     @Test
@@ -117,7 +115,7 @@ public class CDIConfiguredMethodTest {
 
         CDIConfiguredMethod ccm = new CDIConfiguredMethod(ip, keys);
 
-        assertThat(ccm.getSignature(), equalTo(expectedSignature));
+        assertThat(ccm.getSignature()).isEqualTo(expectedSignature);
     }
 
     @Test
@@ -133,7 +131,7 @@ public class CDIConfiguredMethodTest {
 
         CDIConfiguredMethod ccm = new CDIConfiguredMethod(ip, keys);
 
-        assertThat(ccm.getSignature(), equalTo(expectedSignature));
+        assertThat(ccm.getSignature()).isEqualTo(expectedSignature);
     }
 
     @Test
@@ -148,7 +146,7 @@ public class CDIConfiguredMethodTest {
 
         CDIConfiguredMethod ccm = new CDIConfiguredMethod(ip, keys);
 
-        assertThat(ccm.getSignature(), equalTo(expectedSignature));
+        assertThat(ccm.getSignature()).isEqualTo(expectedSignature);
     }
 
     @Test
@@ -163,7 +161,7 @@ public class CDIConfiguredMethodTest {
 
         CDIConfiguredMethod ccm = new CDIConfiguredMethod(ip, keys);
 
-        assertThat(ccm.getSignature(), equalTo(expectedSignature));
+        assertThat(ccm.getSignature()).isEqualTo(expectedSignature);
     }
 
     @Test
@@ -180,7 +178,7 @@ public class CDIConfiguredMethodTest {
 
         CDIConfiguredMethod ccm = new CDIConfiguredMethod(ip, keys);
 
-        assertThat(ccm.getSignature(), equalTo(expectedSignature));
+        assertThat(ccm.getSignature()).isEqualTo(expectedSignature);
     }
 
 }

--- a/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/CDIConfiguredTypeTest.java
+++ b/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/CDIConfiguredTypeTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tamaya.cdi;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CDIConfiguredTypeTest {
 

--- a/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/ConfigurationProducerTest.java
+++ b/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/ConfigurationProducerTest.java
@@ -16,10 +16,6 @@
  */
 package org.apache.tamaya.cdi;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.util.Optional;
 
@@ -36,6 +32,8 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Arquillian.class)
 public class ConfigurationProducerTest {
@@ -56,54 +54,52 @@ public class ConfigurationProducerTest {
 
     @Test
     public void defaultValues() {
-        assertNotNull(allTypes);
-        assertEquals("defaultString", allTypes.getDefaultString());
-        assertEquals(new File("./"), allTypes.getDefaultFile());
-//        assertEquals(new Duration("2 hours and 54 minutes"), allTypes.getDefaultDuration());
-        assertEquals(true, allTypes.getDefaultBoolean());
-        assertEquals(45, (int) allTypes.getDefaultInteger());
+        assertThat(allTypes).isNotNull();
+        assertThat("defaultString").isEqualTo(allTypes.getDefaultString());
+        assertThat(new File("./")).isEqualTo(allTypes.getDefaultFile());
+        assertThat(allTypes.getDefaultBoolean()).isTrue();
+        assertThat(45).isEqualTo((int) allTypes.getDefaultInteger());
     }
 
     @Test
     public void actualPropertyValues() {
-        assertNotNull(allTypes);
-        assertEquals("hello", allTypes.getString());
-        assertEquals(new File("./conf"), allTypes.getFile());
-//        assertEquals(new Duration("10 minutes and 57 seconds"), allTypes.getDuration());
-        assertEquals(true, allTypes.getaBoolean());
-        assertEquals(123, (int) allTypes.getInteger());
+        assertThat(allTypes).isNotNull();
+        assertThat("hello").isEqualTo(allTypes.getString());
+        assertThat(new File("./conf")).isEqualTo(allTypes.getFile());
+        assertThat(allTypes.getaBoolean()).isTrue();
+        assertThat(123).isEqualTo((int) allTypes.getInteger());
     }
 
     @Test
     public void optionalStringFieldIsSet() {
-        assertNotNull(allTypes);
-        assertNotNull(allTypes.optionalString);
-        assertTrue(allTypes.optionalString.isPresent());
-        assertEquals("hello", allTypes.optionalString.get());
+        assertThat(allTypes).isNotNull();
+        assertThat(allTypes.optionalString).isNotNull();
+        assertThat(allTypes.optionalString.isPresent()).isTrue();
+        assertThat("hello").isEqualTo(allTypes.optionalString.get());
     }
 
     @Test
     public void optionalIntegerFieldIsSet() {
-        assertNotNull(allTypes);
-        assertNotNull(allTypes.optionalInteger);
-        assertTrue(allTypes.optionalInteger.isPresent());
-        assertEquals(123, allTypes.optionalInteger.get().longValue());
+        assertThat(allTypes).isNotNull();
+        assertThat(allTypes.optionalInteger).isNotNull();
+        assertThat(allTypes.optionalInteger.isPresent()).isTrue();
+        assertThat(123).isEqualTo(allTypes.optionalInteger.get().longValue());
     }
 
     @Test
     public void providerStringFieldIsSet() {
-        assertNotNull(allTypes);
-        assertNotNull(allTypes.providerString);
-        assertEquals("hello", allTypes.providerString.get());
-        assertEquals("hello", allTypes.providerString.get());
+        assertThat(allTypes).isNotNull();
+        assertThat(allTypes.providerString).isNotNull();
+        assertThat("hello").isEqualTo(allTypes.providerString.get());
+        assertThat("hello").isEqualTo(allTypes.providerString.get());
     }
 
     @Test
     public void providerIntegerFieldIsSet() {
-        assertNotNull(allTypes);
-        assertNotNull(allTypes.providerInteger);
-        assertEquals(123, allTypes.providerInteger.get().longValue());
-        assertEquals(123, allTypes.providerInteger.get().longValue());
+        assertThat(allTypes).isNotNull();
+        assertThat(allTypes.providerInteger).isNotNull();
+        assertThat(123).isEqualTo(allTypes.providerInteger.get().longValue());
+        assertThat(123).isEqualTo(allTypes.providerInteger.get().longValue());
     }
 
     static class AllTypes {

--- a/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/ConfiguredBTest.java
+++ b/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/ConfiguredBTest.java
@@ -19,7 +19,6 @@
  */
 package org.apache.tamaya.cdi;
 
-import org.hamcrest.MatcherAssert;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,11 +26,7 @@ import org.mockito.internal.matchers.NotNull;
 
 import javax.enterprise.inject.spi.CDI;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.internal.matchers.NotNull.NOT_NULL;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for CDI integration.
@@ -45,11 +40,11 @@ public class ConfiguredBTest extends BaseTestConfiguration {
         System.out.println(item);
         System.out.println("********************************************");
         double actual = 1234.5678;
-        MatcherAssert.assertThat(item.getDoubleValue(), is(actual));
-        MatcherAssert.assertThat(item.getExistingDouble(), is(NOT_NULL));
-        MatcherAssert.assertThat(item.getNonExistingDouble(), is(NOT_NULL));
-        MatcherAssert.assertThat(item.getExistingDouble().isPresent(), is(true));
-        MatcherAssert.assertThat(item.getNonExistingDouble().isPresent(), is(false));
-        MatcherAssert.assertThat(item.getExistingDouble().get(), is(actual));
+        assertThat(item.getDoubleValue()).isEqualTo(actual);
+        assertThat(item.getExistingDouble()).isNotNull();
+        assertThat(item.getNonExistingDouble()).isNotNull();
+        assertThat(item.getExistingDouble().isPresent()).isTrue();
+        assertThat(item.getNonExistingDouble().isPresent()).isFalse();
+        assertThat(item.getExistingDouble().get()).isEqualTo(actual);
     }
 }

--- a/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/ConfiguredTest.java
+++ b/modules/injection/cdi/src/test/java/org/apache/tamaya/cdi/ConfiguredTest.java
@@ -25,9 +25,7 @@ import org.junit.runner.RunWith;
 
 import javax.enterprise.inject.spi.CDI;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for CDI integration.
@@ -41,28 +39,28 @@ public class ConfiguredTest extends BaseTestConfiguration {
         System.out.println("********************************************");
         System.out.println(injectedClass);
         System.out.println("********************************************");
-        assertNotNull(injectedClass.builder1);
-        assertNotNull(injectedClass.builder2);
-        assertNotNull(injectedClass.config);
-        assertNotNull(injectedClass.configContext);
+        assertThat(injectedClass.builder1).isNotNull();
+        assertThat(injectedClass.builder2).isNotNull();
+        assertThat(injectedClass.config).isNotNull();
+        assertThat(injectedClass.configContext).isNotNull();
     }
 
     @Test
     public void test_Injected_builders_are_notSame(){
         InjectedClass injectedClass =  CDI.current().select(InjectedClass.class).get();
-        assertTrue(injectedClass.builder1 != injectedClass.builder2);
+        assertThat(injectedClass.builder1 != injectedClass.builder2).isTrue();
     }
 
     @Test
     public void test_Injected_configs_are_same(){
         InjectedClass injectedClass =  CDI.current().select(InjectedClass.class).get();
-        assertTrue(injectedClass.config == injectedClass.config2);
+        assertThat(injectedClass.config == injectedClass.config2).isTrue();
     }
 
     @Test
     public void test_Injected_configContexts_are_same(){
         InjectedClass injectedClass =  CDI.current().select(InjectedClass.class).get();
-        assertTrue(injectedClass.configContext == injectedClass.configContext2);
+        assertThat(injectedClass.configContext == injectedClass.configContext2).isTrue();
     }
 
     @Test(expected=Exception.class)

--- a/modules/injection/injection-api/pom.xml
+++ b/modules/injection/injection-api/pom.xml
@@ -73,10 +73,6 @@ under the License.
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/modules/injection/injection-api/src/test/java/org/apache/tamaya/inject/spi/BaseDynamicValueTest.java
+++ b/modules/injection/injection-api/src/test/java/org/apache/tamaya/inject/spi/BaseDynamicValueTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BaseDynamicValueTest {
 
@@ -46,28 +46,28 @@ public class BaseDynamicValueTest {
         MyDynamicValue dv = new MyDynamicValue(Configuration.current(),"commitAndGet");
         System.setProperty("commitAndGet", "no");
         dv.setUpdatePolicy(UpdatePolicy.EXPLICIT);
-        assertTrue(dv.updateValue());
-        assertEquals(dv.commitAndGet(), "no");
+        assertThat(dv.updateValue()).isTrue();
+        assertThat(dv.commitAndGet()).isEqualTo("no");
         dv.setUpdatePolicy(UpdatePolicy.IMMEDIATE);
         System.setProperty("commitAndGet", "yes2");
-        assertTrue(dv.updateValue());
-        assertEquals(dv.get(), "yes2");
+        assertThat(dv.updateValue()).isTrue();
+        assertThat(dv.get()).isEqualTo("yes2");
     }
 
     @Test
     public void isPresent() throws Exception {
-        assertFalse(new MyDynamicValue(Configuration.current(),"a", "b").isPresent());
-        assertTrue(new MyDynamicValue(Configuration.current(),"java.version").isPresent());
+        assertThat(new MyDynamicValue(Configuration.current(),"a", "b").isPresent()).isFalse();
+        assertThat(new MyDynamicValue(Configuration.current(),"java.version").isPresent()).isTrue();
     }
 
     @Test
     public void orElse() throws Exception {
-        assertEquals(new MyDynamicValue(Configuration.current(),"a", "b").orElse("foo"), "foo");
+        assertThat(new MyDynamicValue(Configuration.current(),"a", "b").orElse("foo")).isEqualTo("foo");
     }
 
     @Test
     public void orElseGet() throws Exception {
-        assertEquals(new MyDynamicValue(Configuration.current(),"a", "b").orElseGet(() -> "foo"), "foo");
+        assertThat(new MyDynamicValue(Configuration.current(),"a", "b").orElseGet(() -> "foo")).isEqualTo("foo");
     }
 
     @Test(expected = NoSuchFieldException.class)

--- a/modules/injection/standalone/pom.xml
+++ b/modules/injection/standalone/pom.xml
@@ -70,6 +70,10 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
             <version>5.0.0</version>

--- a/modules/injection/standalone/pom.xml
+++ b/modules/injection/standalone/pom.xml
@@ -62,10 +62,6 @@ under the License.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/injection/standalone/src/test/java/org/apache/tamaya/inject/TamayaInjectionTest.java
+++ b/modules/injection/standalone/src/test/java/org/apache/tamaya/inject/TamayaInjectionTest.java
@@ -30,9 +30,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by Anatole on 12.01.2015.
@@ -41,76 +39,76 @@ public class TamayaInjectionTest {
 
     @Test
     public void testInjectionNonAnnotatedClass(){
-        assertNotNull(ConfigurationInjection.getConfigurationInjector());
+        assertThat(ConfigurationInjection.getConfigurationInjector()).isNotNull();
         NonAnnotatedConfigBean testInstance = new NonAnnotatedConfigBean();
-        assertEquals(testInstance.simple_value, "Should be overridden!");
-        assertEquals(testInstance.classFieldKey, "Foo");
-        assertEquals(testInstance.fieldKey, null);
-        assertEquals(testInstance.fullKey, null);
-        assertEquals(testInstance.test2, "This is not setCurrent.");
+        assertThat(testInstance.simple_value).isEqualTo("Should be overridden!");
+        assertThat(testInstance.classFieldKey).isEqualTo("Foo");
+        assertThat(testInstance.fieldKey).isNull();
+        assertThat(testInstance.fullKey).isNull();
+        assertThat(testInstance.test2).isEqualTo("This is not setCurrent.");
         ConfigurationInjection.getConfigurationInjector().configure(testInstance);
-        assertEquals(testInstance.simple_value, "aSimpleValue");
-        assertEquals(testInstance.classFieldKey, "Class-Field-Value");
-        assertEquals(testInstance.fieldKey, "Field-Value");
-        assertEquals(testInstance.fullKey, "Fullkey-Value");
-        assertEquals(testInstance.test2, "This is not setCurrent.");
+        assertThat(testInstance.simple_value).isEqualTo("aSimpleValue");
+        assertThat(testInstance.classFieldKey).isEqualTo("Class-Field-Value");
+        assertThat(testInstance.fieldKey).isEqualTo("Field-Value");
+        assertThat(testInstance.fullKey).isEqualTo("Fullkey-Value");
+        assertThat(testInstance.test2).isEqualTo("This is not setCurrent.");
     }
 
     @Test
     public void testInjectionClass(){
-        assertNotNull(ConfigurationInjection.getConfigurationInjector());
+        assertThat(ConfigurationInjection.getConfigurationInjector()).isNotNull();
         AnnotatedConfigBean testInstance = new AnnotatedConfigBean();
-        assertEquals(testInstance.getHostName(), null);
-        assertEquals(testInstance.getAnotherValue(), null);
-        assertEquals(testInstance.myParameter, null);
-        assertEquals(testInstance.simpleValue, null);
+        assertThat(testInstance.getHostName()).isNull();
+        assertThat(testInstance.getAnotherValue()).isNull();
+        assertThat(testInstance.myParameter).isNull();
+        assertThat(testInstance.simpleValue).isNull();
         ConfigurationInjection.getConfigurationInjector().configure(testInstance);
-        assertEquals(testInstance.getHostName(), "tamaya01.incubator.apache.org");
-        assertEquals(testInstance.getAnotherValue(), "HALLO!");
-        assertEquals(testInstance.myParameter, "ET");
-        assertEquals(testInstance.simpleValue, "aSimpleValue");
-        assertNotNull(testInstance.getDynamicValue());
-        assertTrue(testInstance.getDynamicValue().isPresent());
-        assertEquals(testInstance.getDynamicValue().get(), "tamaya01.incubator.apache.org");
-        assertEquals(testInstance.getHostName(), testInstance.getDynamicValue().get());
-        assertEquals(testInstance.javaVersion, System.getProperty("java.version"));
+        assertThat(testInstance.getHostName()).isEqualTo("tamaya01.incubator.apache.org");
+        assertThat(testInstance.getAnotherValue()).isEqualTo("HALLO!");
+        assertThat(testInstance.myParameter).isEqualTo("ET");
+        assertThat(testInstance.simpleValue).isEqualTo("aSimpleValue");
+        assertThat(testInstance.getDynamicValue()).isNotNull();
+        assertThat(testInstance.getDynamicValue().isPresent()).isTrue();
+        assertThat(testInstance.getDynamicValue().get()).isEqualTo("tamaya01.incubator.apache.org");
+        assertThat(testInstance.getHostName()).isEqualTo(testInstance.getDynamicValue().get());
+        assertThat(testInstance.javaVersion).isEqualTo(System.getProperty("java.version"));
     }
-    
+
     @Test
     public void testInjectionInheritedClass(){
-        assertNotNull(ConfigurationInjection.getConfigurationInjector());
+        assertThat(ConfigurationInjection.getConfigurationInjector()).isNotNull();
         InheritedAnnotatedConfigBean testInstance = new InheritedAnnotatedConfigBean();
-        assertEquals(testInstance.getHostName(), null);
-        assertEquals(testInstance.getAnotherValue(), null);
-        assertEquals(testInstance.myParameter, null);
-        assertEquals(testInstance.simpleValue, null);
-        assertEquals(testInstance.someMoreValue, null);
-        assertEquals(testInstance.notConfigured, null);
+        assertThat(testInstance.getHostName()).isNull();
+        assertThat(testInstance.getAnotherValue()).isNull();
+        assertThat(testInstance.myParameter).isNull();
+        assertThat(testInstance.simpleValue).isNull();
+        assertThat(testInstance.someMoreValue).isNull();
+        assertThat(testInstance.notConfigured).isNull();
         ConfigurationInjection.getConfigurationInjector().configure(testInstance);
-        assertEquals(testInstance.getHostName(), "tamaya01.incubator.apache.org");
-        assertEquals(testInstance.getAnotherValue(), "HALLO!");
-        assertEquals(testInstance.myParameter, "ET");
-        assertEquals(testInstance.simpleValue, "aSimpleValue");
-        assertNotNull(testInstance.getDynamicValue());
-        assertTrue(testInstance.getDynamicValue().isPresent());
-        assertEquals(testInstance.getDynamicValue().get(), "tamaya01.incubator.apache.org");
-        assertEquals(testInstance.getHostName(), testInstance.getDynamicValue().get());
-        assertEquals(testInstance.javaVersion, System.getProperty("java.version"));
-        assertEquals(testInstance.someMoreValue, "s'more");
-    }    
+        assertThat(testInstance.getHostName()).isEqualTo("tamaya01.incubator.apache.org");
+        assertThat(testInstance.getAnotherValue()).isEqualTo("HALLO!");
+        assertThat(testInstance.myParameter).isEqualTo("ET");
+        assertThat(testInstance.simpleValue).isEqualTo("aSimpleValue");
+        assertThat(testInstance.getDynamicValue()).isNotNull();
+        assertThat(testInstance.getDynamicValue().isPresent()).isTrue();
+        assertThat(testInstance.getDynamicValue().get()).isEqualTo("tamaya01.incubator.apache.org");
+        assertThat(testInstance.getHostName()).isEqualTo(testInstance.getDynamicValue().get());
+        assertThat(testInstance.javaVersion).isEqualTo(System.getProperty("java.version"));
+        assertThat(testInstance.someMoreValue).isEqualTo("s'more");
+    }
 
     @Test
     public void testConfigTemplate(){
-        assertNotNull(ConfigurationInjection.getConfigurationInjector());
+        assertThat(ConfigurationInjection.getConfigurationInjector()).isNotNull();
         AnnotatedConfigTemplate testInstance = ConfigurationInjection.getConfigurationInjector()
                 .createTemplate(AnnotatedConfigTemplate.class);
-        assertEquals(testInstance.hostName(), "tamaya01.incubator.apache.org");
-        assertEquals(testInstance.myParameter(), "ET");
-        assertEquals(testInstance.simpleValue(), "aSimpleValue");
-        assertNotNull(testInstance.getDynamicValue());
-        assertTrue(testInstance.getDynamicValue().isPresent());
-        assertEquals(testInstance.getDynamicValue().get(), "tamaya01.incubator.apache.org");
-        assertEquals(testInstance.hostName(), testInstance.getDynamicValue().get());
+        assertThat(testInstance.hostName()).isEqualTo("tamaya01.incubator.apache.org");
+        assertThat(testInstance.myParameter()).isEqualTo("ET");
+        assertThat(testInstance.simpleValue()).isEqualTo("aSimpleValue");
+        assertThat(testInstance.getDynamicValue()).isNotNull();
+        assertThat(testInstance.getDynamicValue().isPresent()).isTrue();
+        assertThat(testInstance.getDynamicValue().get()).isEqualTo("tamaya01.incubator.apache.org");
+        assertThat(testInstance.hostName()).isEqualTo(testInstance.getDynamicValue().get());
     }
 
     @Test
@@ -124,16 +122,16 @@ public class TamayaInjectionTest {
         MapPropertySource ps = new MapPropertySource("test", properties);
         Configuration customConfig = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertySources(ps).build();
-        assertNotNull(ConfigurationInjection.getConfigurationInjector());
+        assertThat(ConfigurationInjection.getConfigurationInjector()).isNotNull();
         AnnotatedConfigTemplate testInstance = ConfigurationInjection.getConfigurationInjector()
                 .createTemplate(AnnotatedConfigTemplate.class, customConfig);
-        assertEquals(testInstance.hostName(), "custom-hostname");
-        assertEquals(testInstance.myParameter(), "custom-parameter");
-        assertEquals(testInstance.simpleValue(), "custom-value");
-        assertNotNull(testInstance.getDynamicValue());
-        assertTrue(testInstance.getDynamicValue().isPresent());
-        assertEquals(testInstance.getDynamicValue().get(), "custom-hostname");
-        assertEquals(testInstance.hostName(), testInstance.getDynamicValue().get());
+        assertThat(testInstance.hostName()).isEqualTo("custom-hostname");
+        assertThat(testInstance.myParameter()).isEqualTo("custom-parameter");
+        assertThat(testInstance.simpleValue()).isEqualTo("custom-value");
+        assertThat(testInstance.getDynamicValue()).isNotNull();
+        assertThat(testInstance.getDynamicValue().isPresent()).isTrue();
+        assertThat(testInstance.getDynamicValue().get()).isEqualTo("custom-hostname");
+        assertThat(testInstance.hostName()).isEqualTo(testInstance.getDynamicValue().get());
     }
 
 }

--- a/modules/injection/standalone/src/test/java/org/apache/tamaya/inject/internal/DefaultDynamicValueTest.java
+++ b/modules/injection/standalone/src/test/java/org/apache/tamaya/inject/internal/DefaultDynamicValueTest.java
@@ -34,7 +34,7 @@ import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link org.apache.tamaya.inject.internal.DefaultDynamicValue}.
@@ -91,14 +91,14 @@ public class DefaultDynamicValueTest {
     public void testOf_Field() throws Exception {
         DynamicValue val = DefaultDynamicValue.of(this, getClass().getDeclaredField("myValue"),
                 Configuration.current());
-        assertNotNull(val);
+        assertThat(val).isNotNull();
     }
 
     @Test
     public void testOf_Method() throws Exception {
         DynamicValue val = DefaultDynamicValue.of(this, getClass().getDeclaredMethod("setterMethod", String.class),
                 config);
-        assertNotNull(val);
+        assertThat(val).isNotNull();
     }
 
     @Test
@@ -106,8 +106,8 @@ public class DefaultDynamicValueTest {
         properties.put("a",PropertyValue.of("a","aValue","test"));
         DynamicValue val = DefaultDynamicValue.of(this, getClass().getDeclaredField("myValue"),
                 config);
-        assertNotNull(val);
-        assertEquals("aValue",val.evaluateValue());
+        assertThat(val).isNotNull();
+        assertThat("aValue").isEqualTo(val.evaluateValue());
     }
 
     @Test
@@ -116,13 +116,13 @@ public class DefaultDynamicValueTest {
         DynamicValue val = DefaultDynamicValue.of(this, getClass().getDeclaredField("myValue"),
                 config);
         val.setUpdatePolicy(UpdatePolicy.EXPLICIT);
-        assertNotNull(val);
-        assertEquals("aValue",val.evaluateValue());
+        assertThat(val).isNotNull();
+        assertThat("aValue").isEqualTo(val.evaluateValue());
         // change config
         val.get();
         properties.put("a",PropertyValue.of("a","aValue2","test"));
-        assertTrue(val.updateValue());
-        assertEquals("aValue2", val.commitAndGet());
+        assertThat(val.updateValue()).isTrue();
+        assertThat("aValue2").isEqualTo(val.commitAndGet());
     }
 
     @Test
@@ -131,15 +131,15 @@ public class DefaultDynamicValueTest {
         DynamicValue val = DefaultDynamicValue.of(this, getClass().getDeclaredField("myValue"),
                 config);
         val.setUpdatePolicy(UpdatePolicy.EXPLICIT);
-        assertNotNull(val);
-        assertEquals("aValue", val.evaluateValue());
+        assertThat(val).isNotNull();
+        assertThat("aValue").isEqualTo(val.evaluateValue());
         // change config
         val.get();
         properties.put("a",PropertyValue.of("a","aValue2","test"));
-        assertEquals("aValue2", val.evaluateValue());
-        assertTrue(val.updateValue());
+        assertThat("aValue2").isEqualTo(val.evaluateValue());
+        assertThat(val.updateValue()).isTrue();
         val.commit();
-        assertEquals("aValue2", val.get());
+        assertThat("aValue2").isEqualTo(val.get());
     }
 
     @Test
@@ -148,7 +148,7 @@ public class DefaultDynamicValueTest {
                 config);
         for(UpdatePolicy pol: UpdatePolicy.values()) {
             val.setUpdatePolicy(pol);
-            assertEquals(pol, val.getUpdatePolicy());
+            assertThat(pol).isEqualTo(val.getUpdatePolicy());
         }
     }
 
@@ -163,12 +163,12 @@ public class DefaultDynamicValueTest {
         val.get();
         properties.put("a",PropertyValue.of("a","aValue2","test"));
         val.get();
-        assertNotNull(event);
+        assertThat(event).isNotNull();
         event = null;
         val.removeListener(consumer);
         properties.put("a",PropertyValue.of("a","aValue3","test"));
         val.updateValue();
-        assertNull(event);
+        assertThat(event).isNull();
     }
 
     @Test
@@ -179,7 +179,7 @@ public class DefaultDynamicValueTest {
         val.setUpdatePolicy(UpdatePolicy.IMMEDIATE);
         properties.put("a",PropertyValue.of("a","aValue2","test"));
         val.updateValue();
-        assertEquals("aValue2", val.get());
+        assertThat("aValue2").isEqualTo(val.get());
     }
 
     @Test
@@ -188,13 +188,13 @@ public class DefaultDynamicValueTest {
         DynamicValue val = DefaultDynamicValue.of(this, getClass().getDeclaredField("myValue"),
                 config);
         val.setUpdatePolicy(UpdatePolicy.EXPLICIT);
-        assertNotNull(val.get());
-        assertEquals("aValue", val.get());
+        assertThat(val.get()).isNotNull();
+        assertThat("aValue").isEqualTo(val.get());
         val.updateValue();
-        assertEquals("aValue", val.get());
+        assertThat("aValue").isEqualTo(val.get());
         val.setUpdatePolicy(UpdatePolicy.IMMEDIATE);
         val.updateValue();
-        assertEquals("aValue",val.get());
+        assertThat("aValue").isEqualTo(val.get());
     }
 
     @Test
@@ -203,10 +203,10 @@ public class DefaultDynamicValueTest {
         DynamicValue val = DefaultDynamicValue.of(this, getClass().getDeclaredField("myValue"),
                 config);
         val.setUpdatePolicy(UpdatePolicy.EXPLICIT);
-        assertNotNull(val.get());
-        assertEquals("aValue",val.evaluateValue());
+        assertThat(val.get()).isNotNull();
+        assertThat("aValue").isEqualTo(val.evaluateValue());
         properties.put("a",PropertyValue.of("a","aValue2","test"));
-        assertEquals("aValue2", val.evaluateValue());
+        assertThat("aValue2").isEqualTo(val.evaluateValue());
     }
 
     @Test
@@ -216,19 +216,14 @@ public class DefaultDynamicValueTest {
                 config);
         val.setUpdatePolicy(UpdatePolicy.EXPLICIT);
         val.get();
-        assertNull(val.getNewValue());
+        assertThat(val.getNewValue()).isNull();
         properties.put("a",PropertyValue.of("a","aValue2","test"));
         val.get();
-        assertNotNull(val.getNewValue());
-        assertEquals("aValue2", val.getNewValue());
+        assertThat(val.getNewValue()).isNotNull();
+        assertThat("aValue2").isEqualTo(val.getNewValue());
         val.commit();
-        assertEquals("aValue2", val.get());
-        assertNull(val.getNewValue());
-    }
-
-    @Test
-    public void testIsPresent() throws Exception {
-
+        assertThat("aValue2").isEqualTo(val.get());
+        assertThat(val.getNewValue()).isNull();
     }
 
     @Test
@@ -237,10 +232,10 @@ public class DefaultDynamicValueTest {
         DynamicValue val = DefaultDynamicValue.of(this, getClass().getDeclaredField("myValue"),
                 config);
         val.setUpdatePolicy(UpdatePolicy.IMMEDIATE);
-        assertTrue(val.isPresent());
+        assertThat(val.isPresent()).isTrue();
         properties.remove("a");
         val.updateValue();
-        assertFalse(val.isPresent());
+        assertThat(val.isPresent()).isFalse();
     }
 
     @Test
@@ -248,10 +243,10 @@ public class DefaultDynamicValueTest {
         DynamicValue val = DefaultDynamicValue.of(this, getClass().getDeclaredField("myValue"),
                 config);
         val.setUpdatePolicy(UpdatePolicy.IMMEDIATE);
-        assertEquals("bla", val.orElse("bla"));
+        assertThat("bla").isEqualTo(val.orElse("bla"));
         properties.put("a",PropertyValue.of("a","aValue","test"));
         val.updateValue();
-        assertEquals("aValue", val.orElse("bla"));
+        assertThat("aValue").isEqualTo(val.orElse("bla"));
     }
 
 // TODO reenable with Java 8 support.

--- a/modules/jndi/pom.xml
+++ b/modules/jndi/pom.xml
@@ -64,10 +64,6 @@ under the License.
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/jndi/pom.xml
+++ b/modules/jndi/pom.xml
@@ -72,6 +72,10 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.tamaya</groupId>
             <artifactId>tamaya-spisupport</artifactId>
             <version>${project.version}</version>

--- a/modules/jndi/src/test/java/org/apache/tamaya/jndi/JNDIPropertySourceTest.java
+++ b/modules/jndi/src/test/java/org/apache/tamaya/jndi/JNDIPropertySourceTest.java
@@ -29,10 +29,7 @@ import java.net.MalformedURLException;
 import java.util.Hashtable;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JNDIPropertySourceTest{
 
@@ -55,21 +52,21 @@ public class JNDIPropertySourceTest{
     @Test
     public void testScanContext() throws NamingException, MalformedURLException {
         JNDIPropertySource ps = new JNDIPropertySource("jndi-test", getTestDirContext(createFSContext()));
-        assertFalse(ps.isScannable());
+        assertThat(ps.isScannable()).isFalse();
         Map<String,PropertyValue> props = ps.getProperties();
-        assertNotNull(props);
-        assertTrue(props.isEmpty());
+        assertThat(props).isNotNull();
+        assertThat(props.isEmpty()).isTrue();
         ps.setScannable(true);
-        assertTrue(ps.isScannable());
+        assertThat(ps.isScannable()).isTrue();
         props = ps.getProperties();
-        assertNotNull(props);
-        assertFalse(props.isEmpty());
-        assertEquals(props.size(), 5);
-        assertNotNull(props.get("c.c1.test5"));
-        assertNotNull(props.get("c.test3"));
-        assertNotNull(props.get("c.test4"));
-        assertNotNull(props.get("b.test2"));
-        assertNotNull(props.get("a.test1"));
+        assertThat(props).isNotNull();
+        assertThat(props.isEmpty()).isFalse();
+        assertThat(props).hasSize(5);
+        assertThat(props.get("c.c1.test5")).isNotNull();
+        assertThat(props.get("c.test3")).isNotNull();
+        assertThat(props.get("c.test4")).isNotNull();
+        assertThat(props.get("b.test2")).isNotNull();
+        assertThat(props.get("a.test1")).isNotNull();
     }
 
 }

--- a/modules/microprofile/pom.xml
+++ b/modules/microprofile/pom.xml
@@ -70,11 +70,6 @@ under the License.
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.tamaya</groupId>

--- a/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileAdapterTest.java
+++ b/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileAdapterTest.java
@@ -21,7 +21,6 @@ package org.apache.tamaya.microprofile;
 import org.apache.tamaya.*;
 import org.apache.tamaya.spi.*;
 import org.apache.tamaya.spisupport.propertysource.BuildablePropertySource;
-import org.assertj.core.api.Assertions;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
@@ -31,15 +30,15 @@ import org.junit.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MicroprofileAdapterTest {
     @Test
     public void toConfig() throws Exception {
         Configuration config = Configuration.current();
         Config mpConfig = MicroprofileAdapter.toConfig(config);
-        assertNotNull(mpConfig);
-        assertEquals(config.getProperties().keySet(), mpConfig.getPropertyNames());
+        assertThat(mpConfig).isNotNull();
+        assertThat(config.getProperties().keySet()).isEqualTo(mpConfig.getPropertyNames());
     }
 
     @Test
@@ -50,7 +49,7 @@ public class MicroprofileAdapterTest {
 
         Config result = MicroprofileAdapter.toConfig(tamayaConfiguration);
 
-        Assertions.assertThat(result).isNotNull()
+        assertThat(result).isNotNull()
                   .isInstanceOf(MicroprofileConfig.class)
                   .isSameAs(config);
     }
@@ -59,8 +58,8 @@ public class MicroprofileAdapterTest {
     public void toConfiguration() throws Exception {
         Config mpConfig = ConfigProvider.getConfig();
         Configuration config = MicroprofileAdapter.toConfiguration(mpConfig);
-        assertNotNull(config);
-        assertEquals(mpConfig.getPropertyNames(), config.getProperties().keySet());
+        assertThat(config).isNotNull();
+        assertThat(mpConfig.getPropertyNames()).isEqualTo(config.getProperties().keySet());
     }
 
     @Test
@@ -68,8 +67,7 @@ public class MicroprofileAdapterTest {
         Config config = new MyConfig();
         Configuration result = MicroprofileAdapter.toConfiguration(config);
 
-        Assertions.assertThat(result).isNotNull()
-                  .isInstanceOf(TamayaConfiguration.class);
+        assertThat(result).isNotNull().isInstanceOf(TamayaConfiguration.class);
     }
 
     @Test
@@ -82,17 +80,17 @@ public class MicroprofileAdapterTest {
         List<PropertySource> tamayaSources = new ArrayList<>();
         tamayaSources.add(testPropertySource);
         List<ConfigSource> configSources = MicroprofileAdapter.toConfigSources(tamayaSources);
-        assertNotNull(configSources);
-        assertEquals(tamayaSources.size(), configSources.size());
+        assertThat(configSources).isNotNull()
+            .hasSize(tamayaSources.size());
         compare(testPropertySource, configSources.get(0));
     }
 
     private void compare(PropertySource tamayaSource, ConfigSource mpSource) {
-        assertEquals(mpSource.getName(),tamayaSource.getName());
-        assertEquals(mpSource.getOrdinal(), tamayaSource.getOrdinal());
-        assertEquals(mpSource.getProperties().keySet(), tamayaSource.getProperties().keySet());
+        assertThat(mpSource.getName()).isEqualTo(tamayaSource.getName());
+        assertThat(mpSource.getOrdinal()).isEqualTo(tamayaSource.getOrdinal());
+        assertThat(mpSource.getProperties().keySet()).isEqualTo(tamayaSource.getProperties().keySet());
         for(String key:mpSource.getPropertyNames()){
-            assertEquals(mpSource.getValue(key), tamayaSource.get(key).getValue());
+            assertThat(mpSource.getValue(key)).isEqualTo(tamayaSource.get(key).getValue());
         }
     }
 
@@ -106,8 +104,8 @@ public class MicroprofileAdapterTest {
         List<ConfigSource> configSources = new ArrayList<>();
         configSources.add(configSource);
         List<PropertySource> propertySources = MicroprofileAdapter.toPropertySources(configSources);
-        assertNotNull(propertySources);
-        assertEquals(propertySources.size(), configSources.size());
+        assertThat(propertySources).isNotNull()
+            .hasSize(configSources.size());
         compare(propertySources.get(0), configSource);
     }
 
@@ -119,7 +117,7 @@ public class MicroprofileAdapterTest {
                 .withSimpleProperty("int0", "0")
                 .build();
         ConfigSource configSource = MicroprofileAdapter.toConfigSource(tamayaSource);
-        assertNotNull(configSource);
+        assertThat(configSource).isNotNull();
         compare(tamayaSource, configSource);
     }
 
@@ -131,28 +129,28 @@ public class MicroprofileAdapterTest {
                 .withProperty("int0", "0")
                 .build();
         PropertySource tamayaSource = MicroprofileAdapter.toPropertySource(configSource);
-        assertNotNull(configSource);
+        assertThat(configSource).isNotNull();
         compare(tamayaSource, configSource);
     }
 
     @Test
     public void toPropertyConverter() throws Exception {
         PropertyConverter<String> tamayaConverter = MicroprofileAdapter.toPropertyConverter(new UppercaseConverter());
-        assertNotNull(tamayaConverter);
-        assertEquals("ABC", tamayaConverter.convert("aBC", null));
+        assertThat(tamayaConverter).isNotNull();
+        assertThat("ABC").isEqualTo(tamayaConverter.convert("aBC", null));
     }
 
     @Test
     public void toConverter() throws Exception {
         Converter<String> mpConverter = MicroprofileAdapter.toConverter(new UppercasePropertyConverter());
-        assertNotNull(mpConverter);
-        assertEquals("ABC", mpConverter.convert("aBC"));
+        assertThat(mpConverter).isNotNull();
+        assertThat("ABC").isEqualTo(mpConverter.convert("aBC"));
     }
 
     @Test
     public void toConfigBuilder() throws Exception {
         ConfigBuilder builder = MicroprofileAdapter.toConfigBuilder(Configuration.createConfigurationBuilder());
-        assertNotNull(builder);
+        assertThat(builder).isNotNull();
     }
 
     @Test
@@ -160,9 +158,9 @@ public class MicroprofileAdapterTest {
         Map<String,PropertyValue> props = new HashMap<>();
         props.put("a", PropertyValue.createValue("a","b").setMeta("source", "toStringMap"));
         Map<String, String> mpProps = MicroprofileAdapter.toStringMap(props);
-        assertNotNull(mpProps);
-        assertEquals(props.keySet(), mpProps.keySet());
-        assertEquals(mpProps.get("a"), "b");
+        assertThat(mpProps).isNotNull();
+        assertThat(props.keySet()).isEqualTo(mpProps.keySet());
+        assertThat(mpProps.get("a")).isEqualTo("b");
     }
 
     @Test
@@ -170,10 +168,10 @@ public class MicroprofileAdapterTest {
         Map<String,String> props = new HashMap<>();
         props.put("a", "b");
         Map<String, PropertyValue> tamayaProps = MicroprofileAdapter.toPropertyValueMap(props, "toPropertyValueMap");
-        assertNotNull(tamayaProps);
-        assertEquals(tamayaProps.keySet(), props.keySet());
-        assertEquals(tamayaProps.get("a").getValue(), "b");
-        assertEquals("toPropertyValueMap", tamayaProps.get("a").getMeta("source"));
+        assertThat(tamayaProps).isNotNull();
+        assertThat(tamayaProps.keySet()).isEqualTo(props.keySet());
+        assertThat(tamayaProps.get("a").getValue()).isEqualTo("b");
+        assertThat("toPropertyValueMap").isEqualTo(tamayaProps.get("a").getMeta("source"));
     }
 
     static class MyConfig implements Config {

--- a/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileConfigBuilderTest.java
+++ b/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileConfigBuilderTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tamaya.microprofile;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
@@ -32,7 +31,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 24.03.17.
@@ -64,40 +63,40 @@ public class MicroprofileConfigBuilderTest {
     @Test
     public void testBuildEmptyConfig(){
         ConfigBuilder builder = ConfigProviderResolver.instance().getBuilder();
-        assertNotNull(builder);
+        assertThat(builder).isNotNull();
         Config config = builder.build();
-        assertNotNull(config);
-        assertFalse(config.getPropertyNames().iterator().hasNext());
-        assertFalse(config.getConfigSources().iterator().hasNext());
+        assertThat(config).isNotNull();
+        assertThat(config.getPropertyNames().iterator().hasNext()).isFalse();
+        assertThat(config.getConfigSources().iterator().hasNext()).isFalse();
     }
 
     @Test
     public void testBuildConfig(){
         ConfigBuilder builder = ConfigProviderResolver.instance().getBuilder();
-        assertNotNull(builder);
+        assertThat(builder).isNotNull();
         builder.withSources(testSource);
         Config config = builder.build();
-        assertNotNull(config);
-        assertTrue(config.getPropertyNames().iterator().hasNext());
-        assertTrue(config.getConfigSources().iterator().hasNext());
-        assertNotNull(config.getValue("timestamp", String.class));
+        assertThat(config).isNotNull();
+        assertThat(config.getPropertyNames().iterator().hasNext()).isTrue();
+        assertThat(config.getConfigSources().iterator().hasNext()).isTrue();
+        assertThat(config.getValue("timestamp", String.class)).isNotNull();
         ConfigSource src = config.getConfigSources().iterator().next();
-        assertNotNull(src);
-        assertEquals(src, testSource);
+        assertThat(src).isNotNull();
+        assertThat(src).isEqualTo(testSource);
     }
 
     @Test
     public void testBuildDefaultConfig(){
         ConfigBuilder builder = ConfigProviderResolver.instance().getBuilder();
-        assertNotNull(builder);
+        assertThat(builder).isNotNull();
         builder.addDefaultSources();
         Config config = builder.build();
-        assertNotNull(config);
-        assertTrue(config.getPropertyNames().iterator().hasNext());
-        assertTrue(config.getConfigSources().iterator().hasNext());
-        assertNotNull(config.getValue("java.home", String.class));
+        assertThat(config).isNotNull();
+        assertThat(config.getPropertyNames().iterator().hasNext()).isTrue();
+        assertThat(config.getConfigSources().iterator().hasNext()).isTrue();
+        assertThat(config.getValue("java.home", String.class)).isNotNull();
         ConfigSource src = config.getConfigSources().iterator().next();
-        assertNotNull(src);
+        assertThat(src).isNotNull();
     }
 
     @Test
@@ -113,7 +112,7 @@ public class MicroprofileConfigBuilderTest {
                                          .map(ConfigSource::getName)
                                          .collect(Collectors.toList());
 
-        Assertions.assertThat(name).hasSize(4)
+        assertThat(name).hasSize(4)
                   .containsExactlyInAnyOrder("paris",
                                              "SystemPropertySource",
                                              "environment-properties",

--- a/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileConfigProviderResolverTest.java
+++ b/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileConfigProviderResolverTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 24.03.17.
@@ -35,39 +35,39 @@ public class MicroprofileConfigProviderResolverTest {
 
     @Test
     public void testInstance(){
-        assertNotNull(ConfigProviderResolver.instance());
+        assertThat(ConfigProviderResolver.instance()).isNotNull();
     }
 
     @Test
     public void testGetBuilder(){
-        assertNotNull(ConfigProviderResolver.instance().getBuilder());
+        assertThat(ConfigProviderResolver.instance().getBuilder()).isNotNull();
     }
 
     @Test
     public void testGetConfig(){
-        assertNotNull(ConfigProviderResolver.instance().getConfig());
+        assertThat(ConfigProviderResolver.instance().getConfig()).isNotNull();
     }
 
     @Test
     public void testGetConfig_CL(){
-        assertNotNull(ConfigProviderResolver.instance().getConfig(ClassLoader.getSystemClassLoader()));
+        assertThat(ConfigProviderResolver.instance().getConfig(ClassLoader.getSystemClassLoader())).isNotNull();
     }
 
     @Test
     public void testRegisterAndReleaseConfig(){
         ClassLoader cl = new URLClassLoader(new URL[]{});
         Config emptyConfig = ConfigProviderResolver.instance().getBuilder().build();
-        assertNotNull(emptyConfig);
+        assertThat(emptyConfig).isNotNull();
         Config cfg = ConfigProviderResolver.instance().getConfig(cl);
-        assertNotNull(cfg);
+        assertThat(cfg).isNotNull();
         ConfigProviderResolver.instance().registerConfig(emptyConfig, cl);
         cfg = ConfigProviderResolver.instance().getConfig(cl);
-        assertNotNull(cfg);
-        assertEquals(cfg, emptyConfig);
+        assertThat(cfg).isNotNull();
+        assertThat(cfg).isEqualTo(emptyConfig);
         ConfigProviderResolver.instance().releaseConfig(emptyConfig);
         cfg = ConfigProviderResolver.instance().getConfig(cl);
-        assertNotNull(cfg);
-        assertNotSame(cfg, emptyConfig);
+        assertThat(cfg).isNotNull();
+        assertThat(cfg).isNotSameAs(emptyConfig);
     }
 
 }

--- a/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileConfigProviderTest.java
+++ b/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileConfigProviderTest.java
@@ -23,8 +23,7 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 24.03.17.
@@ -34,28 +33,28 @@ public class MicroprofileConfigProviderTest {
     @Test
     public void testDefaultConfigAccess(){
         Config config = ConfigProvider.getConfig();
-        assertNotNull(config);
+        assertThat(config).isNotNull();
         Iterable<String> names = config.getPropertyNames();
-        assertNotNull(names);
+        assertThat(names).isNotNull();
         int count = 0;
         for(String name:names){
             count++;
             System.out.println(count + ": " +name);
         }
-        assertTrue(Configuration.current().getProperties().size() <= count);
+        assertThat(Configuration.current().getProperties().size() <= count).isTrue();
     }
 
     @Test
     public void testClassloaderAccess(){
         Config config = ConfigProvider.getConfig(Thread.currentThread().getContextClassLoader());
-        assertNotNull(config);
+        assertThat(config).isNotNull();
         Iterable<String> names = config.getPropertyNames();
-        assertNotNull(names);
+        assertThat(names).isNotNull();
         int count = 0;
         for(String name:names){
             count++;
         }
-        assertTrue(count>0);
+        assertThat(count > 0).isTrue();
     }
 
 }

--- a/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileConfigSourceProviderTest.java
+++ b/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileConfigSourceProviderTest.java
@@ -23,7 +23,7 @@ import org.apache.tamaya.spisupport.propertysource.BuildablePropertySourceProvid
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MicroprofileConfigSourceProviderTest {
     @Test
@@ -34,11 +34,11 @@ public class MicroprofileConfigSourceProviderTest {
                         .withSimpleProperty("a", "b").build())
                 .build();
         MicroprofileConfigSourceProvider provider = new MicroprofileConfigSourceProvider(prov);
-        assertNotNull(provider);
+        assertThat(provider).isNotNull();
         Iterable<ConfigSource> configSources = provider.getConfigSources(null);
-        assertNotNull(configSources);
-        assertTrue(configSources.iterator().hasNext());
-        assertEquals("b", configSources.iterator().next().getValue("a"));
+        assertThat(configSources).isNotNull();
+        assertThat(configSources.iterator().hasNext()).isTrue();
+        assertThat("b").isEqualTo(configSources.iterator().next().getValue("a"));
     }
 
 }

--- a/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileConfigTest.java
+++ b/modules/microprofile/src/test/java/org/apache/tamaya/microprofile/MicroprofileConfigTest.java
@@ -30,7 +30,7 @@ import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 24.03.17.
@@ -45,7 +45,7 @@ public class MicroprofileConfigTest {
         for (ConfigSource cs : sources) {
             count++;
         }
-        assertEquals(4, count);
+        assertThat(4).isEqualTo(count);
     }
 
     @Test
@@ -54,10 +54,10 @@ public class MicroprofileConfigTest {
         int count = 0;
         for(String key:config.getPropertyNames()){
             Optional<String> val = config.getOptionalValue(key, String.class);
-            assertNotNull(val);
+            assertThat(val).isNotNull();
             val = config.getOptionalValue(key + System.currentTimeMillis(), String.class);
-            assertNotNull(val);
-            assertFalse(val.isPresent());
+            assertThat(val).isNotNull();
+            assertThat(val.isPresent()).isFalse();
         }
     }
 
@@ -67,7 +67,7 @@ public class MicroprofileConfigTest {
         int count = 0;
         for(String key:config.getPropertyNames()){
             String val = config.getValue(key, String.class);
-            assertNotNull(val);
+            assertThat(val).isNotNull();
         }
     }
 
@@ -87,13 +87,13 @@ public class MicroprofileConfigTest {
     public void testEmptySystemProperty(){
         System.setProperty("my.empty.property", "");
         Config config = ConfigProvider.getConfig();
-        assertEquals("", config.getValue("my.empty.property", String.class));
+        assertThat("").isEqualTo(config.getValue("my.empty.property", String.class));
     }
 
     @Test
     public void testEmptyConfigProperty(){
         Config config = ConfigProvider.getConfig();
-        assertEquals("", config.getValue("my.empty.property.in.config.file", String.class));
+        assertThat("").isEqualTo(config.getValue("my.empty.property.in.config.file", String.class));
     }
 
 }

--- a/modules/mutable-config/pom.xml
+++ b/modules/mutable-config/pom.xml
@@ -78,10 +78,6 @@ under the License.
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/mutable-config/pom.xml
+++ b/modules/mutable-config/pom.xml
@@ -81,10 +81,13 @@ under the License.
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.tamaya.ext</groupId>

--- a/modules/mutable-config/src/test/java/org/apache/tamaya/mutableconfig/ChangePropagationPolicyTest.java
+++ b/modules/mutable-config/src/test/java/org/apache/tamaya/mutableconfig/ChangePropagationPolicyTest.java
@@ -20,27 +20,27 @@ package org.apache.tamaya.mutableconfig;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ChangePropagationPolicyTest {
 
     @Test
     public void getApplyAllChangePolicy() throws Exception {
-        assertNotNull(ChangePropagationPolicy.ALL_POLICY);
+        assertThat(ChangePropagationPolicy.ALL_POLICY).isNotNull();
     }
 
     @Test
     public void getApplyMostSignificantOnlyChangePolicy() throws Exception {
-        assertNotNull(ChangePropagationPolicy.MOST_SIGNIFICANT_ONLY_POLICY);
+        assertThat(ChangePropagationPolicy.MOST_SIGNIFICANT_ONLY_POLICY).isNotNull();
     }
 
     @Test
     public void getApplySelectiveChangePolicy() throws Exception {
-        assertNotNull(ChangePropagationPolicy.getApplySelectiveChangePolicy("bla"));
+        assertThat(ChangePropagationPolicy.getApplySelectiveChangePolicy("bla")).isNotNull();
     }
 
     @Test
     public void getApplyNonePolicy() throws Exception {
-        assertNotNull(ChangePropagationPolicy.NONE_POLICY);
+        assertThat(ChangePropagationPolicy.NONE_POLICY).isNotNull();
     }
 }

--- a/modules/mutable-config/src/test/java/org/apache/tamaya/mutableconfig/MutableConfigurationProviderTest.java
+++ b/modules/mutable-config/src/test/java/org/apache/tamaya/mutableconfig/MutableConfigurationProviderTest.java
@@ -21,7 +21,7 @@ package org.apache.tamaya.mutableconfig;
 import org.apache.tamaya.Configuration;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 26.08.16.
@@ -29,16 +29,16 @@ import static org.junit.Assert.*;
 public class MutableConfigurationProviderTest {
     @Test
     public void createMutableConfiguration() throws Exception {
-        assertNotNull(MutableConfigurationProvider.getInstance().createMutableConfiguration());
+        assertThat(MutableConfigurationProvider.getInstance().createMutableConfiguration()).isNotNull();
     }
 
     @Test
     public void createMutableConfiguration1() throws Exception {
         MutableConfiguration cfg = MutableConfigurationProvider.getInstance()
                 .createMutableConfiguration(Configuration.current());
-        assertNotNull(cfg);
-        assertEquals(cfg.getChangePropagationPolicy(),
-                ChangePropagationPolicy.MOST_SIGNIFICANT_ONLY_POLICY);
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.getChangePropagationPolicy())
+            .isEqualTo(ChangePropagationPolicy.MOST_SIGNIFICANT_ONLY_POLICY);
     }
 
     @Test
@@ -47,8 +47,8 @@ public class MutableConfigurationProviderTest {
         MutableConfiguration cfg = MutableConfigurationProvider.getInstance()
                 .createMutableConfiguration(Configuration.current(),
                         policy);
-        assertNotNull(cfg);
-        assertEquals(cfg.getChangePropagationPolicy(), policy);
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.getChangePropagationPolicy()).isEqualTo(policy);
     }
 
     @Test
@@ -56,28 +56,28 @@ public class MutableConfigurationProviderTest {
         ChangePropagationPolicy policy = ChangePropagationPolicy.getApplySelectiveChangePolicy("gugus");
         MutableConfiguration cfg = MutableConfigurationProvider.getInstance()
                 .createMutableConfiguration(policy);
-        assertNotNull(cfg);
-        assertEquals(cfg.getChangePropagationPolicy(), policy);
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.getChangePropagationPolicy()).isEqualTo(policy);
     }
 
     @Test
     public void getApplyAllChangePolicy() throws Exception {
-        assertNotNull(MutableConfigurationProvider.getApplyAllChangePolicy());
+        assertThat(MutableConfigurationProvider.getApplyAllChangePolicy()).isNotNull();
     }
 
     @Test
     public void getApplyMostSignificantOnlyChangePolicy() throws Exception {
-        assertNotNull(MutableConfigurationProvider.getApplyMostSignificantOnlyChangePolicy());
+        assertThat(MutableConfigurationProvider.getApplyMostSignificantOnlyChangePolicy()).isNotNull();
     }
 
     @Test
     public void getApplySelectiveChangePolicy() throws Exception {
-        assertNotNull(MutableConfigurationProvider.getApplySelectiveChangePolicy());
+        assertThat(MutableConfigurationProvider.getApplySelectiveChangePolicy()).isNotNull();
     }
 
     @Test
     public void getApplyNonePolicy() throws Exception {
-        assertNotNull(MutableConfigurationProvider.getApplyNonePolicy());
+        assertThat(MutableConfigurationProvider.getApplyNonePolicy()).isNotNull();
     }
 
 }

--- a/modules/mutable-config/src/test/java/org/apache/tamaya/mutableconfig/MutableConfigurationTest.java
+++ b/modules/mutable-config/src/test/java/org/apache/tamaya/mutableconfig/MutableConfigurationTest.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link MutableConfiguration}.
@@ -38,15 +38,15 @@ public class MutableConfigurationTest {
 
     @Test
     public void createMutableConfiguration() throws Exception {
-        assertNotNull(MutableConfiguration.create());
+        assertThat(MutableConfiguration.create()).isNotNull();
     }
 
     @Test
     public void createMutableConfiguration1() throws Exception {
         MutableConfiguration cfg = MutableConfiguration.create(Configuration.current());
-        assertNotNull(cfg);
-        assertEquals(cfg.getChangePropagationPolicy(),
-                ChangePropagationPolicy.MOST_SIGNIFICANT_ONLY_POLICY);
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.getChangePropagationPolicy())
+                .isEqualTo(ChangePropagationPolicy.MOST_SIGNIFICANT_ONLY_POLICY);
     }
 
     @Test
@@ -55,8 +55,8 @@ public class MutableConfigurationTest {
         MutableConfiguration cfg = MutableConfiguration
                 .create(Configuration.current(),
                         policy);
-        assertNotNull(cfg);
-        assertEquals(cfg.getChangePropagationPolicy(), policy);
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.getChangePropagationPolicy()).isEqualTo(policy);
     }
 
     @Test
@@ -64,8 +64,8 @@ public class MutableConfigurationTest {
         ChangePropagationPolicy policy = ChangePropagationPolicy.getApplySelectiveChangePolicy("gugus");
         MutableConfiguration cfg = MutableConfiguration
                 .create(policy);
-        assertNotNull(cfg);
-        assertEquals(cfg.getChangePropagationPolicy(), policy);
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.getChangePropagationPolicy()).isEqualTo(policy);
     }
 
     /**
@@ -79,14 +79,14 @@ public class MutableConfigurationTest {
         MutableConfiguration cfg1 = MutableConfiguration.create(
                 Configuration.current(),
                 ChangePropagationPolicy.ALL_POLICY);
-        assertNotNull(cfg1);
-        assertNotNull(cfg1.getConfigChangeRequest());
+        assertThat(cfg1).isNotNull();
+        assertThat(cfg1.getConfigChangeRequest()).isNotNull();
         MutableConfiguration cfg2 = MutableConfiguration.create(
                 Configuration.current());
-        assertNotNull(cfg2);
-        assertNotNull(cfg2.getConfigChangeRequest());
-        assertTrue(cfg1!=cfg2);
-        assertTrue(cfg1.getConfigChangeRequest()!=cfg2.getConfigChangeRequest());
+        assertThat(cfg2).isNotNull();
+        assertThat(cfg2.getConfigChangeRequest()).isNotNull();
+        assertThat(cfg1).isNotEqualTo(cfg2);
+        assertThat(cfg1.getConfigChangeRequest()).isNotEqualTo(cfg2.getConfigChangeRequest());
     }
 
     /**
@@ -145,7 +145,7 @@ public class MutableConfigurationTest {
         cm.put("key3", "value3");
         mutConfig.putAll(cm);
         mutConfig.store();
-        assertTrue(WritablePropertiesSource.target.exists());
+        assertThat(WritablePropertiesSource.target.exists()).isTrue();
         MutableConfiguration mmutConfig2 = MutableConfiguration.create(
                 Configuration.current()
         );
@@ -156,10 +156,10 @@ public class MutableConfigurationTest {
         mmutConfig2.store();
         Properties props = new Properties();
         props.load(WritablePropertiesSource.target.toURL().openStream());
-        assertEquals(3, props.size());
-        assertEquals("value1.2", props.getProperty("key1"));
-        assertEquals("value2", props.getProperty("key2"));
-        assertEquals("value4", props.getProperty("key4"));
+        assertThat(props).hasSize(3);
+        assertThat("value1.2").isEqualTo(props.getProperty("key1"));
+        assertThat("value2").isEqualTo(props.getProperty("key2"));
+        assertThat("value4").isEqualTo(props.getProperty("key4"));
     }
 
     /**
@@ -178,10 +178,10 @@ public class MutableConfigurationTest {
         cm.put("key3", "value3");
         cfg.putAll(cm);
         cfg.store();
-        assertTrue(WritableXmlPropertiesSource.target.exists());
+        assertThat(WritableXmlPropertiesSource.target.exists()).isTrue();
         MutableConfiguration cfg2 = MutableConfiguration.create(
                 Configuration.current());
-        assertTrue(cfg != cfg2);
+        assertThat(cfg).isNotEqualTo(cfg2);
         cfg2.remove("foo");
         cfg2.remove("key3");
         cfg2.put("key1", "value1.2");
@@ -189,9 +189,9 @@ public class MutableConfigurationTest {
         cfg2.store();
         Properties props = new Properties();
         props.loadFromXML( WritableXmlPropertiesSource.target.toURL().openStream());
-        assertEquals(3, props.size());
-        assertEquals("value1", props.getProperty("key1"));
-        assertEquals("value2", props.getProperty("key2"));
+        assertThat(props).hasSize(3);
+        assertThat("value1").isEqualTo(props.getProperty("key1"));
+        assertThat("value2").isEqualTo(props.getProperty("key2"));
     }
 
     /**
@@ -211,7 +211,7 @@ public class MutableConfigurationTest {
         cm.put("key3", "value3");
         cfg.putAll(cm);
         cfg.store();
-        assertFalse(WritableXmlPropertiesSource.target.exists());
+        assertThat(WritableXmlPropertiesSource.target.exists()).isFalse();
     }
 
 }

--- a/modules/optional/pom.xml
+++ b/modules/optional/pom.xml
@@ -80,6 +80,10 @@ under the License.
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/modules/optional/pom.xml
+++ b/modules/optional/pom.xml
@@ -73,10 +73,6 @@ under the License.
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/optional/src/test/java/org/apache/tamaya/optional/OptionalConfigurationTest.java
+++ b/modules/optional/src/test/java/org/apache/tamaya/optional/OptionalConfigurationTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tamaya.optional;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by Anatole on 07.09.2015.
@@ -34,10 +34,10 @@ public class OptionalConfigurationTest {
                 return (T)"result";
             }
         });
-        assertNotNull(cfg);
-        assertEquals(cfg.get("sdkjsdkjsdkjhskjdh"), "result");
-        assertEquals(cfg.get("sdkjsdkjsdsdsdkjhskjdh", String.class), "result");
-        assertEquals(cfg.get("java.version", String.class), "result");
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.get("sdkjsdkjsdkjhskjdh")).isEqualTo("result");
+        assertThat(cfg.get("sdkjsdkjsdsdsdkjhskjdh", String.class)).isEqualTo("result");
+        assertThat(cfg.get("java.version", String.class)).isEqualTo("result");
     }
 
     @org.junit.Test
@@ -48,10 +48,10 @@ public class OptionalConfigurationTest {
                 return (T)"result";
             }
         });
-        assertNotNull(cfg);
-        assertEquals(cfg.get("sdkjsdkjsdkjhskjdh"), "result");
-        assertEquals(cfg.get("sdkjsdkjsdsdsdkjhskjdh", String.class), "result");
-        assertEquals(cfg.get("java.version", String.class), System.getProperty("java.version"));
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.get("sdkjsdkjsdkjhskjdh")).isEqualTo("result");
+        assertThat(cfg.get("sdkjsdkjsdsdsdkjhskjdh", String.class)).isEqualTo("result");
+        assertThat(cfg.get("java.version", String.class)).isEqualTo(System.getProperty("java.version"));
     }
 
     @org.junit.Test(expected = IllegalStateException.class)
@@ -65,38 +65,38 @@ public class OptionalConfigurationTest {
                 return (T)"result";
             }
         });
-        assertNotNull(cfg);
-        assertEquals(cfg.get("sdkjsdkjsdkjhskjdh"), "result");
-        assertEquals(cfg.get("sdkjsdkjsdsdsdkjhskjdh", String.class), "result");
-        assertEquals(cfg.get("java.version", String.class), System.getProperty("java.version"));
-        assertEquals(cfg.get("java.version", String.class), "dfdf");
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.get("sdkjsdkjsdkjhskjdh")).isEqualTo("result");
+        assertThat(cfg.get("sdkjsdkjsdsdsdkjhskjdh", String.class)).isEqualTo("result");
+        assertThat(cfg.get("java.version", String.class)).isEqualTo(System.getProperty("java.version"));
+        assertThat(cfg.get("java.version", String.class)).isEqualTo("dfdf");
     }
 
     @org.junit.Test
     public void testOf_NOPROV_THROWS_EXCEPTION() throws Exception {
         OptionalConfiguration cfg = OptionalConfiguration.of(EvaluationPolicy.THROWS_EXCEPTION);
-        assertNotNull(cfg);
-        assertNull(cfg.get("sdkjsdkjsdkjhskjdh"));
-        assertEquals(cfg.get("java.version"), System.getProperty("java.version"));
-        assertEquals(cfg.get("java.version", String.class), System.getProperty("java.version"));
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.get("sdkjsdkjsdkjhskjdh")).isNull();
+        assertThat(cfg.get("java.version")).isEqualTo(System.getProperty("java.version"));
+        assertThat(cfg.get("java.version", String.class)).isEqualTo(System.getProperty("java.version"));
     }
 
     @org.junit.Test
     public void testOf_NOPROV_TAMAYA_OVERRIDES_OTHER() throws Exception {
         OptionalConfiguration cfg = OptionalConfiguration.of(EvaluationPolicy.TAMAYA_OVERRIDES_OTHER);
-        assertNotNull(cfg);
-        assertNull(cfg.get("sdkjsdkjsdkjhskjdh"));
-        assertEquals(cfg.get("java.version"), System.getProperty("java.version"));
-        assertEquals(cfg.get("java.version", String.class), System.getProperty("java.version"));
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.get("sdkjsdkjsdkjhskjdh")).isNull();
+        assertThat(cfg.get("java.version")).isEqualTo(System.getProperty("java.version"));
+        assertThat(cfg.get("java.version", String.class)).isEqualTo(System.getProperty("java.version"));
     }
 
     @org.junit.Test
     public void testOf_NOPROV_OTHER_OVERRIDES_TAMAYA() throws Exception {
         OptionalConfiguration cfg = OptionalConfiguration.of(EvaluationPolicy.OTHER_OVERRIDES_TAMAYA);
-        assertNotNull(cfg);
-        assertNull(cfg.get("sdkjsdkjsdkjhskjdh"));
-        assertEquals(cfg.get("java.version"), System.getProperty("java.version"));
-        assertEquals(cfg.get("java.version", String.class), System.getProperty("java.version"));
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.get("sdkjsdkjsdkjhskjdh")).isNull();
+        assertThat(cfg.get("java.version")).isEqualTo(System.getProperty("java.version"));
+        assertThat(cfg.get("java.version", String.class)).isEqualTo(System.getProperty("java.version"));
     }
 
 }

--- a/modules/osgi/common/pom.xml
+++ b/modules/osgi/common/pom.xml
@@ -85,6 +85,10 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/modules/osgi/common/pom.xml
+++ b/modules/osgi/common/pom.xml
@@ -74,10 +74,6 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/BackupsTest.java
+++ b/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/BackupsTest.java
@@ -24,7 +24,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
@@ -41,25 +41,25 @@ public class BackupsTest {
     public void setGet() throws Exception {
         Dictionary<String,Object> cfg = createConfig("setCurrent");
         Backups.set("setCurrent", cfg);
-        assertEquals(Backups.get("setCurrent"), cfg);
+        assertThat(Backups.get("setCurrent")).isEqualTo(cfg);
     }
 
     @Test
     public void remove() throws Exception {
         Dictionary<String,Object> cfg = createConfig("remove");
         Backups.set("remove", cfg);
-        assertEquals(Backups.get("remove"), cfg);
+        assertThat(Backups.get("remove")).isEqualTo(cfg);
         Backups.remove("remove");
-        assertEquals(Backups.get("remove"), null);
+        assertThat(Backups.get("remove")).isNull();
     }
 
     @Test
     public void removeAll() throws Exception {
         Dictionary<String,Object> cfg = createConfig("remove");
         Backups.set("remove", cfg);
-        assertEquals(Backups.get("remove"), cfg);
+        assertThat(Backups.get("remove")).isEqualTo(cfg);
         Backups.removeAll();
-        assertEquals(Backups.get("remove"), null);
+        assertThat(Backups.get("remove")).isNull();
     }
 
     @Test
@@ -71,23 +71,23 @@ public class BackupsTest {
         Dictionary<String,Object> cfg = createConfig("getPids");
         Backups.set("getPids", cfg);
         Set<String> pids = Backups.getPids();
-        assertNotNull(pids);
-        assertTrue(pids.contains("getPids"));
+        assertThat(pids).isNotNull();
+        assertThat(pids.contains("getPids")).isTrue();
         Backups.removeAll();
         pids = Backups.getPids();
-        assertNotNull(pids);
-        assertTrue(pids.isEmpty());
+        assertThat(pids).isNotNull();
+        assertThat(pids.isEmpty()).isTrue();
     }
 
     @Test
     public void contains() throws Exception {
         Dictionary<String,Object> cfg = createConfig("contains");
         Backups.set("contains", cfg);
-        assertTrue(Backups.contains("contains"));
-        assertFalse(Backups.contains("foo"));
+        assertThat(Backups.contains("contains")).isTrue();
+        assertThat(Backups.contains("foo")).isFalse();
         Backups.removeAll();
-        assertFalse(Backups.contains("contains"));
-        assertFalse(Backups.contains("foo"));
+        assertThat(Backups.contains("contains")).isFalse();
+        assertThat(Backups.contains("foo")).isFalse();
     }
 
     @Test
@@ -97,10 +97,10 @@ public class BackupsTest {
         Backups.set("saveRestore", cfg);
         Backups.save(store);
         Backups.removeAll();
-        assertFalse(Backups.contains("saveRestore"));
+        assertThat(Backups.contains("saveRestore")).isFalse();
         Backups.restore(store);
-        assertTrue(Backups.contains("saveRestore"));
-        assertEquals(Backups.get("saveRestore"), cfg);
+        assertThat(Backups.contains("saveRestore")).isTrue();
+        assertThat(Backups.get("saveRestore")).isEqualTo(cfg);
     }
 
 }

--- a/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/ConfigHistoryTest.java
+++ b/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/ConfigHistoryTest.java
@@ -24,7 +24,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
@@ -34,36 +34,36 @@ public class ConfigHistoryTest {
     @Test
     public void configuring() throws Exception {
         ConfigHistory en = ConfigHistory.configuring("configuring", "configuring_test");
-        assertNotNull(en);
-        assertEquals("configuring", en.getPid());
-        assertEquals(ConfigHistory.TaskType.BEGIN, en.getType());
-        assertEquals("configuring_test", en.getValue());
+        assertThat(en).isNotNull();
+        assertThat("configuring").isEqualTo(en.getPid());
+        assertThat(ConfigHistory.TaskType.BEGIN).isEqualTo(en.getType());
+        assertThat("configuring_test").isEqualTo(en.getValue());
     }
 
     @Test
     public void configured() throws Exception {
         ConfigHistory en = ConfigHistory.configured("configured", "configured_test");
-        assertNotNull(en);
-        assertEquals("configured", en.getPid());
-        assertEquals(ConfigHistory.TaskType.END, en.getType());
-        assertEquals("configured_test", en.getValue());
+        assertThat(en).isNotNull();
+        assertThat("configured").isEqualTo(en.getPid());
+        assertThat(ConfigHistory.TaskType.END).isEqualTo(en.getType());
+        assertThat("configured_test").isEqualTo(en.getValue());
     }
 
     @Test
     public void propertySet() throws Exception {
         ConfigHistory en = ConfigHistory.propertySet("propertySet", "propertySet.key", "new", "prev");
-        assertNotNull(en);
-        assertEquals("propertySet", en.getPid());
-        assertEquals(ConfigHistory.TaskType.PROPERTY, en.getType());
-        assertEquals("propertySet.key", en.getKey());
-        assertEquals("prev", en.getPreviousValue());
-        assertEquals("new", en.getValue());
+        assertThat(en).isNotNull();
+        assertThat("propertySet").isEqualTo(en.getPid());
+        assertThat(ConfigHistory.TaskType.PROPERTY).isEqualTo(en.getType());
+        assertThat("propertySet.key").isEqualTo(en.getKey());
+        assertThat("prev").isEqualTo(en.getPreviousValue());
+        assertThat("new").isEqualTo(en.getValue());
     }
 
     @Test
     public void setGetMaxHistory() throws Exception {
         ConfigHistory.setMaxHistory(1000);
-        assertEquals(1000, ConfigHistory.getMaxHistory());
+        assertThat(1000).isEqualTo(ConfigHistory.getMaxHistory());
     }
 
     @Test
@@ -72,8 +72,8 @@ public class ConfigHistoryTest {
             ConfigHistory.propertySet("getHistory", "getHistory"+i, "prev"+i, "new"+i);
         }
         List<ConfigHistory> hist = ConfigHistory.getHistory();
-        assertNotNull(hist);
-        assertTrue(hist.size()>=100);
+        assertThat(hist).isNotNull();
+        assertThat(hist.size() >= 100).isTrue();
     }
 
     @Test
@@ -87,14 +87,14 @@ public class ConfigHistoryTest {
             ConfigHistory.propertySet("history2", "getHistory"+i, "prev"+i, "new"+i);
         }
         List<ConfigHistory> hist = ConfigHistory.getHistory("history1");
-        assertNotNull(hist);
-        assertEquals(102, hist.size());
+        assertThat(hist).isNotNull();
+        assertThat(102).isEqualTo(hist.size());
         hist = ConfigHistory.getHistory("history2");
-        assertNotNull(hist);
-        assertEquals(100, hist.size());
+        assertThat(hist).isNotNull();
+        assertThat(100).isEqualTo(hist.size());
         hist = ConfigHistory.getHistory(null);
-        assertNotNull(hist);
-        assertTrue(hist.size()>202);
+        assertThat(hist).isNotNull();
+        assertThat(hist.size() > 202).isTrue();
     }
 
     @Test
@@ -106,15 +106,15 @@ public class ConfigHistoryTest {
             ConfigHistory.propertySet("history4", "getHistory"+i, "prev"+i, "new"+i);
         }
         List<ConfigHistory> hist = ConfigHistory.getHistory("history3");
-        assertNotNull(hist);
-        assertEquals(100, hist.size());
-        assertEquals(100, ConfigHistory.getHistory("history4").size());
+        assertThat(hist).isNotNull();
+        assertThat(hist).hasSize(100);
+        assertThat(ConfigHistory.getHistory("history4")).hasSize(100);
         ConfigHistory.clearHistory("history3");
-        assertEquals(0, ConfigHistory.getHistory("history3").size());
-        assertEquals(100, ConfigHistory.getHistory("history4").size());
+        assertThat(ConfigHistory.getHistory("history3")).hasSize(0);
+        assertThat(ConfigHistory.getHistory("history4")).hasSize(100);
         ConfigHistory.clearHistory(null);
-        assertTrue(ConfigHistory.getHistory().isEmpty());
-        assertTrue(ConfigHistory.getHistory("history4").isEmpty());
+        assertThat(ConfigHistory.getHistory().isEmpty()).isTrue();
+        assertThat(ConfigHistory.getHistory("history4").isEmpty()).isTrue();
     }
 
 
@@ -138,14 +138,14 @@ public class ConfigHistoryTest {
         for(int i=0;i<10;i++){
             ConfigHistory.propertySet("save", "getHistory"+i, "prev"+i, "new"+i);
         }
-        assertEquals(10, ConfigHistory.getHistory("save").size());
+        assertThat(ConfigHistory.getHistory("save")).hasSize(10);
         Dictionary<String,Object> config = new Hashtable<>();
         ConfigHistory.save(config);
-        assertEquals(10, ConfigHistory.getHistory("save").size());
+        assertThat(ConfigHistory.getHistory("save")).hasSize(10);
         ConfigHistory.clearHistory();
-        assertTrue(ConfigHistory.getHistory("save").isEmpty());
+        assertThat(ConfigHistory.getHistory("save").isEmpty()).isTrue();
         ConfigHistory.restore(config);
-        assertEquals(10, ConfigHistory.getHistory("save").size());
+        assertThat(ConfigHistory.getHistory("save")).hasSize(10);
     }
 
 }

--- a/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/TamayaConfigPluginTest.java
+++ b/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/TamayaConfigPluginTest.java
@@ -25,7 +25,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 10.12.16.
@@ -35,13 +35,13 @@ public class TamayaConfigPluginTest extends  AbstractOSGITest{
 
     @Test
     public void pluginLoaded() throws Exception {
-        assertNotNull(bundleContext.getService(bundleContext.getServiceReference(TamayaConfigPlugin.class)));
+        assertThat(bundleContext.getService(bundleContext.getServiceReference(TamayaConfigPlugin.class))).isNotNull();
     }
 
     @Test
     public void testOperationMode() throws Exception {
         tamayaConfigPlugin.setDefaultPolicy(Policy.EXTEND);
-        assertEquals(Policy.EXTEND, tamayaConfigPlugin.getDefaultPolicy());
+        assertThat(Policy.EXTEND).isEqualTo(tamayaConfigPlugin.getDefaultPolicy());
         tamayaConfigPlugin.setDefaultPolicy(Policy.OVERRIDE);
     }
 
@@ -49,239 +49,239 @@ public class TamayaConfigPluginTest extends  AbstractOSGITest{
     public void testAutoUpdate() throws Exception {
         boolean autoUpdate = tamayaConfigPlugin.isAutoUpdateEnabled();
         tamayaConfigPlugin.setAutoUpdateEnabled(!autoUpdate);
-        assertEquals(tamayaConfigPlugin.isAutoUpdateEnabled(),!autoUpdate);
+        assertThat(tamayaConfigPlugin.isAutoUpdateEnabled()).isEqualTo(!autoUpdate);
         tamayaConfigPlugin.setAutoUpdateEnabled(autoUpdate);
-        assertEquals(tamayaConfigPlugin.isAutoUpdateEnabled(),autoUpdate);
+        assertThat(tamayaConfigPlugin.isAutoUpdateEnabled()).isEqualTo(autoUpdate);
     }
 
     @Test
     public void testDefaulEnabled() throws Exception {
         boolean enabled = tamayaConfigPlugin.isTamayaEnabledByDefault();
         tamayaConfigPlugin.setTamayaEnabledByDefault(!enabled);
-        assertEquals(tamayaConfigPlugin.isTamayaEnabledByDefault(),!enabled);
+        assertThat(tamayaConfigPlugin.isTamayaEnabledByDefault()).isEqualTo(!enabled);
         tamayaConfigPlugin.setTamayaEnabledByDefault(enabled);
-        assertEquals(tamayaConfigPlugin.isTamayaEnabledByDefault(),enabled);
+        assertThat(tamayaConfigPlugin.isTamayaEnabledByDefault()).isEqualTo(enabled);
     }
 
     @Test
     public void testSetPluginConfig() throws Exception {
         Dictionary<String,Object> config = new Hashtable<>();
         ((TamayaConfigPlugin)tamayaConfigPlugin).setPluginConfig(config);
-        assertEquals(((TamayaConfigPlugin)tamayaConfigPlugin).getPluginConfig(), config);
+        assertThat(((TamayaConfigPlugin)tamayaConfigPlugin).getPluginConfig()).isEqualTo(config);
     }
 
     @Test
     public void testSetGetConfigValue() throws Exception {
         ((TamayaConfigPlugin)tamayaConfigPlugin).setConfigValue("bar", "foo");
-        assertEquals(((TamayaConfigPlugin)tamayaConfigPlugin).getConfigValue("bar"), "foo");
+        assertThat(((TamayaConfigPlugin)tamayaConfigPlugin).getConfigValue("bar")).isEqualTo("foo");
     }
 
     @Test
     public void getTMUpdateConfig() throws Exception {
         org.apache.tamaya.Configuration config = ((TamayaConfigPlugin)tamayaConfigPlugin).getTamayaConfiguration("java.");
-        assertNotNull(config);
-        assertNull(config.get("jlkjllj"));
-        assertEquals(System.getProperty("java.home"), config.get("home"));
+        assertThat(config).isNotNull();
+        assertThat(config.get("jlkjllj")).isNull();
+        assertThat(System.getProperty("java.home")).isEqualTo(config.get("home"));
     }
 
     @Test
     public void getUpdateConfig() throws Exception {
         Dictionary<String, Object> config = tamayaConfigPlugin.updateConfig(TamayaConfigPlugin.COMPONENTID);
-        assertNotNull(config);
-        assertEquals(System.getProperty("java.home"), config.get("java.home"));
+        assertThat(config).isNotNull();
+        assertThat(System.getProperty("java.home")).isEqualTo(config.get("java.home"));
     }
 
     @Test
     public void getUpdateConfig_DryRun() throws Exception {
         Dictionary<String, Object> config = tamayaConfigPlugin.updateConfig(TamayaConfigPlugin.COMPONENTID, true);
-        assertNotNull(config);
-        assertEquals(System.getProperty("java.home"), config.get("java.home"));
+        assertThat(config).isNotNull();
+        assertThat(System.getProperty("java.home")).isEqualTo(config.get("java.home"));
     }
 
     @Test
     public void getUpdateConfig_Explicit_DryRun() throws Exception {
         Dictionary<String, Object> config = tamayaConfigPlugin.updateConfig(TamayaConfigPlugin.COMPONENTID, Policy.EXTEND, true, true);
-        assertNotNull(config);
-        assertEquals(config.get("java.home"), System.getProperty("java.home"));
+        assertThat(config).isNotNull();
+        assertThat(config.get("java.home")).isEqualTo(System.getProperty("java.home"));
     }
 
     @Test
     public void getPluginConfig() throws Exception {
         Dictionary<String, Object> config = ((TamayaConfigPlugin)tamayaConfigPlugin).getPluginConfig();
-        assertNotNull(config);
-        assertEquals(super.getProperties(TamayaConfigPlugin.COMPONENTID), config);
+        assertThat(config).isNotNull();
+        assertThat(super.getProperties(TamayaConfigPlugin.COMPONENTID)).isEqualTo(config);
     }
 
     @Test
     public void getDefaultOperationMode() throws Exception {
         Policy om = tamayaConfigPlugin.getDefaultPolicy();
-        assertNotNull(om);
+        assertThat(om).isNotNull();
         Dictionary<String,Object> pluginConfig = super.getProperties(TamayaConfigPlugin.COMPONENTID);
         pluginConfig.put(Policy.class.getSimpleName(), Policy.UPDATE_ONLY.toString());
         TamayaConfigPlugin plugin = new TamayaConfigPlugin(bundleContext);
         om = plugin.getDefaultPolicy();
-        assertNotNull(om);
-        assertEquals(Policy.UPDATE_ONLY, om);
+        assertThat(om).isNotNull();
+        assertThat(Policy.UPDATE_ONLY).isEqualTo(om);
         pluginConfig.put(Policy.class.getSimpleName(), Policy.OVERRIDE.toString());
         plugin = new TamayaConfigPlugin(bundleContext);
         om = plugin.getDefaultPolicy();
-        assertNotNull(om);
-        assertEquals(Policy.OVERRIDE, om);
+        assertThat(om).isNotNull();
+        assertThat(Policy.OVERRIDE).isEqualTo(om);
     }
 
     @Test
     public void testConfiguration_Override() throws Exception {
-        assertNotNull(cm);
+        assertThat(cm).isNotNull();
         tamayaConfigPlugin.updateConfig("tamaya", Policy.OVERRIDE, true, false);
         org.osgi.service.cm.Configuration config = cm.getConfiguration("tamaya");
-        assertNotNull(config);
-        assertNotNull(config.getProperties());
-        assertFalse(config.getProperties().isEmpty());
-        assertTrue(config.getProperties().size() > 4);
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isNotNull();
+        assertThat(config.getProperties().isEmpty()).isFalse();
+        assertThat(config.getProperties().size() > 4).isTrue();
         // Override should add additional values
-        assertEquals("success1", config.getProperties().get("my.testProperty1"));
-        assertEquals("success2", config.getProperties().get("my.testProperty2"));
-        assertEquals("success3", config.getProperties().get("my.testProperty3"));
-        assertEquals("success4", config.getProperties().get("my.testProperty4"));
+        assertThat("success1").isEqualTo(config.getProperties().get("my.testProperty1"));
+        assertThat("success2").isEqualTo(config.getProperties().get("my.testProperty2"));
+        assertThat("success3").isEqualTo(config.getProperties().get("my.testProperty3"));
+        assertThat("success4").isEqualTo(config.getProperties().get("my.testProperty4"));
         // Extend should also update any existing values...
-        assertEquals("Java2000", config.getProperties().get("java.version"));
+        assertThat("Java2000").isEqualTo(config.getProperties().get("java.version"));
         tamayaConfigPlugin.restoreBackup("tamaya");
     }
 
     @Test
     public void testConfiguration_Override_ImplicitlyConfigured() throws Exception {
-        assertNotNull(cm);
+        assertThat(cm).isNotNull();
         org.osgi.service.cm.Configuration config = cm.getConfiguration("tamaya");
         Dictionary<String,Object> props = config.getProperties();
         props.put(TamayaConfigPlugin.TAMAYA_POLICY_PROP, "OVERRIDE");
         config.update(props);
         tamayaConfigPlugin.updateConfig("tamaya", Policy.UPDATE_ONLY, false, false);
         config = cm.getConfiguration("tamaya");
-        assertNotNull(config);
-        assertNotNull(config.getProperties());
-        assertFalse(config.getProperties().isEmpty());
-        assertTrue(config.getProperties().size() > 4);
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isNotNull();
+        assertThat(config.getProperties().isEmpty()).isFalse();
+        assertThat(config.getProperties().size() > 4).isTrue();
         // Override should add additional values
-        assertEquals("success1", config.getProperties().get("my.testProperty1"));
-        assertEquals("success2", config.getProperties().get("my.testProperty2"));
-        assertEquals("success3", config.getProperties().get("my.testProperty3"));
-        assertEquals("success4", config.getProperties().get("my.testProperty4"));
+        assertThat("success1").isEqualTo(config.getProperties().get("my.testProperty1"));
+        assertThat("success2").isEqualTo(config.getProperties().get("my.testProperty2"));
+        assertThat("success3").isEqualTo(config.getProperties().get("my.testProperty3"));
+        assertThat("success4").isEqualTo(config.getProperties().get("my.testProperty4"));
         // Extend should also update any existing values...
-        assertEquals("Java2000", config.getProperties().get("java.version"));
+        assertThat("Java2000").isEqualTo(config.getProperties().get("java.version"));
         tamayaConfigPlugin.restoreBackup("tamaya");
     }
 
     @Test
     public void testConfiguration_Extend() throws Exception {
-        assertNotNull(cm);
+        assertThat(cm).isNotNull();
         tamayaConfigPlugin.updateConfig("tamaya", Policy.EXTEND, true, false);
         org.osgi.service.cm.Configuration config = cm.getConfiguration("tamaya");
-        assertNotNull(config);
-        assertNotNull(config.getProperties());
-        assertFalse(config.getProperties().isEmpty());
-        assertTrue(config.getProperties().size() > 4);
-        assertEquals(config.getProperties().get("my.testProperty1"), "success1");
-        assertEquals(config.getProperties().get("my.testProperty2"), "success2");
-        assertEquals(config.getProperties().get("my.testProperty3"), "success3");
-        assertEquals(config.getProperties().get("my.testProperty4"), "success4");
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isNotNull();
+        assertThat(config.getProperties().isEmpty()).isFalse();
+        assertThat(config.getProperties().size() > 4).isTrue();
+        assertThat(config.getProperties().get("my.testProperty1")).isEqualTo("success1");
+        assertThat(config.getProperties().get("my.testProperty2")).isEqualTo("success2");
+        assertThat(config.getProperties().get("my.testProperty3")).isEqualTo("success3");
+        assertThat(config.getProperties().get("my.testProperty4")).isEqualTo("success4");
         // Extend should not update any existing values...
-        assertEquals(config.getProperties().get("java.version"), System.getProperty("java.version"));
+        assertThat(config.getProperties().get("java.version")).isEqualTo(System.getProperty("java.version"));
         tamayaConfigPlugin.restoreBackup("tamaya");
     }
 
     @Test
     public void testConfiguration_Update_Only() throws Exception {
-        assertNotNull(cm);
+        assertThat(cm).isNotNull();
         tamayaConfigPlugin.updateConfig("tamaya", Policy.UPDATE_ONLY, true, false);
         org.osgi.service.cm.Configuration config = cm.getConfiguration("tamaya");
-        assertNotNull(config);
-        assertNotNull(config.getProperties());
-        assertFalse(config.getProperties().isEmpty());
-        assertTrue(config.getProperties().size() > 4);
-        assertEquals(config.getProperties().get("my.testProperty1"), null);
-        assertEquals(config.getProperties().get("my.testProperty2"), null);
-        assertEquals(config.getProperties().get("my.testProperty3"), null);
-        assertEquals(config.getProperties().get("my.testProperty4"), null);
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isNotNull();
+        assertThat(config.getProperties().isEmpty()).isFalse();
+        assertThat(config.getProperties().size() > 4).isTrue();
+        assertThat(config.getProperties().get("my.testProperty1")).isNull();
+        assertThat(config.getProperties().get("my.testProperty2")).isNull();
+        assertThat(config.getProperties().get("my.testProperty3")).isNull();
+        assertThat(config.getProperties().get("my.testProperty4")).isNull();
         // Update only should update any existing values...
-        assertEquals(config.getProperties().get("java.version"), "Java2000");
+        assertThat(config.getProperties().get("java.version")).isEqualTo("Java2000");
         tamayaConfigPlugin.restoreBackup("tamaya");
     }
 
     @Test
     public void testConfiguration_Override_Dryrun() throws Exception {
-        assertNotNull(cm);
+        assertThat(cm).isNotNull();
         Dictionary<String,Object> result = tamayaConfigPlugin.updateConfig("tamaya", Policy.OVERRIDE, true, true);
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         // Override should add additional values
-        assertEquals(result.get("my.testProperty1"), "success1");
-        assertEquals(result.get("my.testProperty2"), "success2");
-        assertEquals(result.get("my.testProperty3"), "success3");
-        assertEquals(result.get("my.testProperty4"), "success4");
+        assertThat(result.get("my.testProperty1")).isEqualTo("success1");
+        assertThat(result.get("my.testProperty2")).isEqualTo("success2");
+        assertThat(result.get("my.testProperty3")).isEqualTo("success3");
+        assertThat(result.get("my.testProperty4")).isEqualTo("success4");
         // Extend should also update any existing values...
-        assertEquals(result.get("java.version"), "Java2000");
+        assertThat(result.get("java.version")).isEqualTo("Java2000");
 
         // DryRun: should not have been changged anything on OSGI level...
         org.osgi.service.cm.Configuration config = cm.getConfiguration("tamaya");
-        assertNotNull(config);
-        assertNotNull(config.getProperties());
-        assertFalse(config.getProperties().isEmpty());
-        assertTrue(config.getProperties().size() > 4);
-        assertEquals(config.getProperties().get("my.testProperty1"), null);
-        assertEquals(config.getProperties().get("my.testProperty2"), null);
-        assertEquals(config.getProperties().get("my.testProperty3"), null);
-        assertEquals(config.getProperties().get("my.testProperty4"), null);
-        assertEquals(config.getProperties().get("java.version"), System.getProperty("java.version"));
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isNotNull();
+        assertThat(config.getProperties().isEmpty()).isFalse();
+        assertThat(config.getProperties().size() > 4).isTrue();
+        assertThat(config.getProperties().get("my.testProperty1")).isNull();
+        assertThat(config.getProperties().get("my.testProperty2")).isNull();
+        assertThat(config.getProperties().get("my.testProperty3")).isNull();
+        assertThat(config.getProperties().get("my.testProperty4")).isNull();
+        assertThat(config.getProperties().get("java.version")).isEqualTo(System.getProperty("java.version"));
     }
 
     @Test
     public void testConfiguration_Extend_Dryrun() throws Exception {
-        assertNotNull(cm);
+        assertThat(cm).isNotNull();
         Dictionary<String,Object> result = tamayaConfigPlugin.updateConfig("tamaya", Policy.EXTEND, true, true);
-        assertNotNull(result);
-        assertEquals(result.get("my.testProperty1"), "success1");
-        assertEquals(result.get("my.testProperty2"), "success2");
-        assertEquals(result.get("my.testProperty3"), "success3");
-        assertEquals(result.get("my.testProperty4"), "success4");
+        assertThat(result).isNotNull();
+        assertThat(result.get("my.testProperty1")).isEqualTo("success1");
+        assertThat(result.get("my.testProperty2")).isEqualTo("success2");
+        assertThat(result.get("my.testProperty3")).isEqualTo("success3");
+        assertThat(result.get("my.testProperty4")).isEqualTo("success4");
         // Extend should not update any existing values...
-        assertEquals(result.get("java.version"), System.getProperty("java.version"));
+        assertThat(result.get("java.version")).isEqualTo(System.getProperty("java.version"));
 
         // DryRun: should not have been changged anything on OSGI level...
         org.osgi.service.cm.Configuration config = cm.getConfiguration("tamaya");
-        assertNotNull(config);
-        assertNotNull(config.getProperties());
-        assertFalse(config.getProperties().isEmpty());
-        assertTrue(config.getProperties().size() > 4);
-        assertEquals(config.getProperties().get("my.testProperty1"), null);
-        assertEquals(config.getProperties().get("my.testProperty2"), null);
-        assertEquals(config.getProperties().get("my.testProperty3"), null);
-        assertEquals(config.getProperties().get("my.testProperty4"), null);
-        assertEquals(config.getProperties().get("java.version"), System.getProperty("java.version"));
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isNotNull();
+        assertThat(config.getProperties().isEmpty()).isFalse();
+        assertThat(config.getProperties().size() > 4).isTrue();
+        assertThat(config.getProperties().get("my.testProperty1")).isNull();
+        assertThat(config.getProperties().get("my.testProperty2")).isNull();
+        assertThat(config.getProperties().get("my.testProperty3")).isNull();
+        assertThat(config.getProperties().get("my.testProperty4")).isNull();
+        assertThat(config.getProperties().get("java.version")).isEqualTo(System.getProperty("java.version"));
     }
 
     @Test
     public void testConfiguration_Update_Only_Dryrun() throws Exception {
-        assertNotNull(cm);
+        assertThat(cm).isNotNull();
         Dictionary<String,Object> result = tamayaConfigPlugin.updateConfig("tamaya", Policy.UPDATE_ONLY, true, true);
-        assertNotNull(result);
-        assertTrue(result.size() > 4);
-        assertEquals(result.get("my.testProperty1"), null);
-        assertEquals(result.get("my.testProperty2"), null);
-        assertEquals(result.get("my.testProperty3"), null);
-        assertEquals(result.get("my.testProperty4"), null);
+        assertThat(result).isNotNull();
+        assertThat(result.size() > 4).isTrue();
+        assertThat(result.get("my.testProperty1")).isNull();
+        assertThat(result.get("my.testProperty2")).isNull();
+        assertThat(result.get("my.testProperty3")).isNull();
+        assertThat(result.get("my.testProperty4")).isNull();
         // Update only should update any existing values...
-        assertEquals(result.get("java.version"), "Java2000");
+        assertThat(result.get("java.version")).isEqualTo("Java2000");
 
         // DryRun: should not have been changged anything on OSGI level...
         org.osgi.service.cm.Configuration config = cm.getConfiguration("tamaya");
-        assertNotNull(config);
-        assertNotNull(config.getProperties());
-        assertFalse(config.getProperties().isEmpty());
-        assertTrue(config.getProperties().size() > 4);
-        assertEquals(config.getProperties().get("my.testProperty1"), null);
-        assertEquals(config.getProperties().get("my.testProperty2"), null);
-        assertEquals(config.getProperties().get("my.testProperty3"), null);
-        assertEquals(config.getProperties().get("my.testProperty4"), null);
-        assertEquals(config.getProperties().get("java.version"), System.getProperty("java.version"));
+        assertThat(config).isNotNull();
+        assertThat(config.getProperties()).isNotNull();
+        assertThat(config.getProperties().isEmpty()).isFalse();
+        assertThat(config.getProperties().size() > 4).isTrue();
+        assertThat(config.getProperties().get("my.testProperty1")).isNull();
+        assertThat(config.getProperties().get("my.testProperty2")).isNull();
+        assertThat(config.getProperties().get("my.testProperty3")).isNull();
+        assertThat(config.getProperties().get("my.testProperty4")).isNull();
+        assertThat(config.getProperties().get("java.version")).isEqualTo(System.getProperty("java.version"));
     }
 
 }

--- a/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/commands/BackupCommandsTest.java
+++ b/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/commands/BackupCommandsTest.java
@@ -25,7 +25,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Hashtable;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 30.09.2017.
@@ -35,49 +35,49 @@ public class BackupCommandsTest extends AbstractOSGITest {
     @Test
     public void createBackup() throws Exception {
         String result = BackupCommands.createBackup(tamayaConfigPlugin, cm, "createBackup", false);
-        assertNotNull(result);
-        assertTrue(result.contains("createBackup"));
-        assertTrue(result.contains("Backup created"));
-        assertTrue(tamayaConfigPlugin.containsBackup("createBackup"));
+        assertThat(result).isNotNull();
+        assertThat(result.contains("createBackup")).isTrue();
+        assertThat(result.contains("Backup created")).isTrue();
+        assertThat(tamayaConfigPlugin.containsBackup("createBackup")).isTrue();
         // A backup with the given name already exists, so it fails
         result = BackupCommands.createBackup(tamayaConfigPlugin, cm, "createBackup", false);
-        assertNotNull(result);
-        assertTrue(result.contains("createBackup"));
-        assertTrue(result.contains("Creating of backup failed"));
-        assertTrue(result.contains("already existing"));
-        assertTrue(tamayaConfigPlugin.containsBackup("createBackup"));
+        assertThat(result).isNotNull();
+        assertThat(result.contains("createBackup")).isTrue();
+        assertThat(result.contains("Creating of backup failed")).isTrue();
+        assertThat(result.contains("already existing")).isTrue();
+        assertThat(tamayaConfigPlugin.containsBackup("createBackup")).isTrue();
         // any existing backups gets overridden
         result = BackupCommands.createBackup(tamayaConfigPlugin, cm, "createBackup", true);
-        assertNotNull(result);
-        assertTrue(result.contains("createBackup"));
-        assertTrue(result.contains("Backup created"));
-        assertTrue(tamayaConfigPlugin.containsBackup("createBackup"));
+        assertThat(result).isNotNull();
+        assertThat(result.contains("createBackup")).isTrue();
+        assertThat(result.contains("Backup created")).isTrue();
+        assertThat(tamayaConfigPlugin.containsBackup("createBackup")).isTrue();
     }
 
     @Test
     public void deleteBackup() throws Exception {
         BackupCommands.createBackup(tamayaConfigPlugin, cm, "deleteBackup", false);
-        assertTrue(tamayaConfigPlugin.containsBackup("deleteBackup"));
+        assertThat(tamayaConfigPlugin.containsBackup("deleteBackup")).isTrue();
         String result = BackupCommands.deleteBackup(tamayaConfigPlugin, "deleteBackup");
-        assertNotNull(result);
-        assertTrue(result.contains("deleteBackup"));
-        assertTrue(result.contains("Backup deleted"));
-        assertFalse(tamayaConfigPlugin.containsBackup("deleteBackup"));
+        assertThat(result).isNotNull();
+        assertThat(result.contains("deleteBackup")).isTrue();
+        assertThat(result.contains("Backup deleted")).isTrue();
+        assertThat(tamayaConfigPlugin.containsBackup("deleteBackup")).isFalse();
     }
 
     @Test
     public void restoreBackup() throws Exception {
         BackupCommands.createBackup(tamayaConfigPlugin, cm, "restoreBackup", false);
-        assertTrue(tamayaConfigPlugin.containsBackup("restoreBackup"));
+        assertThat(tamayaConfigPlugin.containsBackup("restoreBackup")).isTrue();
         String result = BackupCommands.restoreBackup(tamayaConfigPlugin, "restoreBackup");
-        assertNotNull(result);
-        assertTrue(result.contains("restoreBackup"));
-        assertTrue(result.contains("Backup restored"));
+        assertThat(result).isNotNull();
+        assertThat(result.contains("restoreBackup")).isTrue();
+        assertThat(result.contains("Backup restored")).isTrue();
         BackupCommands.deleteBackup(tamayaConfigPlugin, "restoreBackup");
-        assertFalse(tamayaConfigPlugin.containsBackup("restoreBackup"));
+        assertThat(tamayaConfigPlugin.containsBackup("restoreBackup")).isFalse();
         result = BackupCommands.restoreBackup(tamayaConfigPlugin, "restoreBackup");
-        assertTrue(result.contains("Backup restore failed"));
-        assertTrue(result.contains("no backup found"));
+        assertThat(result.contains("Backup restore failed")).isTrue();
+        assertThat(result.contains("no backup found")).isTrue();
     }
 
     @Test
@@ -94,10 +94,10 @@ public class BackupCommandsTest extends AbstractOSGITest {
         props.put("k1", "v1");
         props.put("k2", "v2");
         String result = BackupCommands.printProps(props);
-        assertTrue(result.contains("k1"));
-        assertTrue(result.contains("k2"));
-        assertTrue(result.contains("v1"));
-        assertTrue(result.contains("v2"));
+        assertThat(result.contains("k1")).isTrue();
+        assertThat(result.contains("k2")).isTrue();
+        assertThat(result.contains("v1")).isTrue();
+        assertThat(result.contains("v2")).isTrue();
     }
 
 }

--- a/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/commands/ConfigCommandsTest.java
+++ b/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/commands/ConfigCommandsTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 30.09.2017.
@@ -34,133 +34,133 @@ public class ConfigCommandsTest extends AbstractOSGITest{
     @Test
     public void getInfo() throws Exception {
         String result = ConfigCommands.getInfo(tamayaConfigPlugin);
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         System.out.println(result);
-        assertTrue(result.contains("Property Sources"));
-        assertTrue(result.contains("Property Converter"));
-        assertTrue(result.contains("Property Filter"));
-        assertTrue(result.contains("ConfigurationContext"));
-        assertTrue(result.contains("Configuration"));
+        assertThat(result.contains("Property Sources")).isTrue();
+        assertThat(result.contains("Property Converter")).isTrue();
+        assertThat(result.contains("Property Filter")).isTrue();
+        assertThat(result.contains("ConfigurationContext")).isTrue();
+        assertThat(result.contains("Configuration")).isTrue();
     }
 
     @Test
     public void readTamayaConfig() throws Exception {
         String result = ConfigCommands.readTamayaConfig("java", null);
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         System.out.println(result);
-        assertTrue(result.contains(".version"));
-        assertTrue(result.contains("Section"));
-        assertTrue(result.contains("java"));
+        assertThat(result.contains(".version")).isTrue();
+        assertThat(result.contains("Section")).isTrue();
+        assertThat(result.contains("java")).isTrue();
         result = ConfigCommands.readTamayaConfig("java", "version");
-        assertNotNull(result);
-        assertFalse(result.contains(".version"));
-        assertTrue(result.contains("Section"));
-        assertTrue(result.contains("java"));
-        assertTrue(result.contains("Filter"));
-        assertTrue(result.contains("version"));
-        assertFalse(result.contains("java.vendor"));
+        assertThat(result).isNotNull();
+        assertThat(result.contains(".version")).isFalse();
+        assertThat(result.contains("Section")).isTrue();
+        assertThat(result.contains("java")).isTrue();
+        assertThat(result.contains("Filter")).isTrue();
+        assertThat(result.contains("version")).isTrue();
+        assertThat(result.contains("java.vendor")).isFalse();
         System.out.println("readTamayaConfig: " + result);
     }
 
     @Test
     public void readTamayaConfig4PID() throws Exception {
         String result = ConfigCommands.readTamayaConfig4PID("test", null);
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         System.out.println(result);
-        assertTrue(result.contains("Configuration"));
-        assertTrue(result.contains("test"));
+        assertThat(result.contains("Configuration")).isTrue();
+        assertThat(result.contains("test")).isTrue();
     }
 
     @Test
     public void applyTamayaConfiguration() throws Exception {
         String result = ConfigCommands.applyTamayaConfiguration(tamayaConfigPlugin, "applyTamayaConfiguration", Policy.OVERRIDE.toString(), true);
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         System.out.println(result);
-        assertTrue(result.contains("OSGI Configuration for PID"));
-        assertTrue(result.contains("applyTamayaConfiguration"));
-        assertTrue(result.contains("OVERRIDE"));
-        assertTrue(result.contains("Dryrun"));
-        assertTrue(result.contains("true"));
+        assertThat(result.contains("OSGI Configuration for PID")).isTrue();
+        assertThat(result.contains("applyTamayaConfiguration")).isTrue();
+        assertThat(result.contains("OVERRIDE")).isTrue();
+        assertThat(result.contains("Dryrun")).isTrue();
+        assertThat(result.contains("true")).isTrue();
     }
 
     @Test
     public void readOSGIConfiguration() throws Exception {
         String result = ConfigCommands.readOSGIConfiguration(tamayaConfigPlugin, "readOSGIConfiguration", "java");
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         System.out.println(result);
-        assertTrue(result.contains("OSGI Configuration for PID"));
-        assertTrue(result.contains("readOSGIConfiguration"));
-        assertTrue(result.contains("java.home"));
+        assertThat(result.contains("OSGI Configuration for PID")).isTrue();
+        assertThat(result.contains("readOSGIConfiguration")).isTrue();
+        assertThat(result.contains("java.home")).isTrue();
     }
 
     @Test
     public void getDefaultOpPolicy() throws Exception {
         Policy mode = tamayaConfigPlugin.getDefaultPolicy();
         String result = ConfigCommands.getDefaultOpPolicy(tamayaConfigPlugin);
-        assertNotNull(result);
-        assertTrue(result.contains(mode.toString()));
+        assertThat(result).isNotNull();
+        assertThat(result.contains(mode.toString())).isTrue();
     }
 
     @Test
     public void setDefaultOpPolicy() throws Exception {
         String result = ConfigCommands.setDefaultOpPolicy(tamayaConfigPlugin, Policy.EXTEND.toString());
-        assertNotNull(result);
-        assertTrue(result.contains("EXTEND"));
-        assertEquals(tamayaConfigPlugin.getDefaultPolicy(), Policy.EXTEND);
+        assertThat(result).isNotNull();
+        assertThat(result.contains("EXTEND")).isTrue();
+        assertThat(tamayaConfigPlugin.getDefaultPolicy()).isEqualTo(Policy.EXTEND);
         result = ConfigCommands.setDefaultOpPolicy(tamayaConfigPlugin, Policy.UPDATE_ONLY.toString());
-        assertNotNull(result);
-        assertTrue(result.contains("UPDATE_ONLY"));
-        assertEquals(tamayaConfigPlugin.getDefaultPolicy(), Policy.UPDATE_ONLY);
+        assertThat(result).isNotNull();
+        assertThat(result.contains("UPDATE_ONLY")).isTrue();
+        assertThat(tamayaConfigPlugin.getDefaultPolicy()).isEqualTo(Policy.UPDATE_ONLY);
     }
 
     @Test
     public void getProperty() throws Exception {
         String result = ConfigCommands.getProperty("system-properties", "java.version", false);
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         System.out.println(result);
-        assertEquals(result, System.getProperty("java.version"));
+        assertThat(result).isEqualTo(System.getProperty("java.version"));
         result = ConfigCommands.getProperty("system-properties", "java.version", true);
-        assertNotNull(result);
+        assertThat(result).isNotNull();
     }
 
     @Test
     public void getPropertySource() throws Exception {
         String result = ConfigCommands.getPropertySource("system-properties");
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         System.out.println(result);
-        assertTrue(result.contains("Property Source"));
-        assertTrue(result.contains("ID"));
-        assertTrue(result.contains("system-properties"));
-        assertTrue(result.contains("Ordinal"));
-        assertTrue(result.contains("java.version"));
+        assertThat(result.contains("Property Source")).isTrue();
+        assertThat(result.contains("ID")).isTrue();
+        assertThat(result.contains("system-properties")).isTrue();
+        assertThat(result.contains("Ordinal")).isTrue();
+        assertThat(result.contains("java.version")).isTrue();
     }
 
     @Test
     public void getPropertySourceOverview() throws Exception {
         String result = ConfigCommands.getPropertySourceOverview();
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         System.out.println(result);
-        assertTrue(result.contains("Ordinal"));
-        assertTrue(result.contains("Class"));
-        assertTrue(result.contains("Ordinal"));
-        assertTrue(result.contains("ID"));
-        assertTrue(result.contains("Ordinal"));
-        assertTrue(result.contains("system-properties"));
-        assertTrue(result.contains("environment-properties"));
-        assertTrue(result.contains("CLI"));
+        assertThat(result.contains("Ordinal")).isTrue();
+        assertThat(result.contains("Class")).isTrue();
+        assertThat(result.contains("Ordinal")).isTrue();
+        assertThat(result.contains("ID")).isTrue();
+        assertThat(result.contains("Ordinal")).isTrue();
+        assertThat(result.contains("system-properties")).isTrue();
+        assertThat(result.contains("environment-properties")).isTrue();
+        assertThat(result.contains("CLI")).isTrue();
     }
 
     @Test
     public void setDefaultEnabled() throws Exception {
         String result = ConfigCommands.setDefaultEnabled(tamayaConfigPlugin, true);
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         System.out.println(result);
-        assertTrue(result.contains(TamayaConfigService.TAMAYA_ENABLED_PROP+"=true"));
-        assertTrue(tamayaConfigPlugin.isTamayaEnabledByDefault());
+        assertThat(result.contains(TamayaConfigService.TAMAYA_ENABLED_PROP+"=true")).isTrue();
+        assertThat(tamayaConfigPlugin.isTamayaEnabledByDefault()).isTrue();
         result = ConfigCommands.setDefaultEnabled(tamayaConfigPlugin, false);
-        assertNotNull(result);
-        assertTrue(result.contains(TamayaConfigService.TAMAYA_ENABLED_PROP+"=false"));
-        assertFalse(tamayaConfigPlugin.isTamayaEnabledByDefault());
+        assertThat(result).isNotNull();
+        assertThat(result.contains(TamayaConfigService.TAMAYA_ENABLED_PROP+"=false")).isTrue();
+        assertThat(tamayaConfigPlugin.isTamayaEnabledByDefault()).isFalse();
     }
 
     @Test
@@ -170,23 +170,23 @@ public class ConfigCommandsTest extends AbstractOSGITest{
         System.out.println(result);
         tamayaConfigPlugin.setTamayaEnabledByDefault(false);
         result = ConfigCommands.getDefaultEnabled(tamayaConfigPlugin);
-        assertNotNull(result);
-        assertTrue(result.equals("false"));
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo("false");
     }
 
     @Test
     public void setAutoUpdateEnabled() throws Exception {
         String result = ConfigCommands.setAutoUpdateEnabled(tamayaConfigPlugin, true);
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         System.out.println(result);
-        assertTrue(result.contains("true"));
-        assertTrue(result.contains(TamayaConfigService.TAMAYA_AUTO_UPDATE_ENABLED_PROP));
-        assertTrue(tamayaConfigPlugin.isAutoUpdateEnabled());
+        assertThat(result.contains("true")).isTrue();
+        assertThat(result.contains(TamayaConfigService.TAMAYA_AUTO_UPDATE_ENABLED_PROP)).isTrue();
+        assertThat(tamayaConfigPlugin.isAutoUpdateEnabled()).isTrue();
         result = ConfigCommands.setAutoUpdateEnabled(tamayaConfigPlugin, false);
-        assertNotNull(result);
-        assertTrue(result.contains("false"));
-        assertTrue(result.contains(TamayaConfigService.TAMAYA_AUTO_UPDATE_ENABLED_PROP));
-        assertFalse(tamayaConfigPlugin.isAutoUpdateEnabled());
+        assertThat(result).isNotNull();
+        assertThat(result.contains("false")).isTrue();
+        assertThat(result.contains(TamayaConfigService.TAMAYA_AUTO_UPDATE_ENABLED_PROP)).isTrue();
+        assertThat(tamayaConfigPlugin.isAutoUpdateEnabled()).isFalse();
     }
 
     @Test
@@ -194,11 +194,11 @@ public class ConfigCommandsTest extends AbstractOSGITest{
         tamayaConfigPlugin.setAutoUpdateEnabled(true);
         String result = ConfigCommands.getAutoUpdateEnabled(tamayaConfigPlugin);
         System.out.println(result);
-        assertTrue(result.contains("true"));
+        assertThat(result.contains("true")).isTrue();
         tamayaConfigPlugin.setAutoUpdateEnabled(false);
         result = ConfigCommands.getAutoUpdateEnabled(tamayaConfigPlugin);
-        assertNotNull(result);
-        assertTrue(result.contains("false"));
+        assertThat(result).isNotNull();
+        assertThat(result.contains("false")).isTrue();
     }
 
 }

--- a/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/commands/HistoryCommandsTest.java
+++ b/modules/osgi/common/src/test/java/org/apache/tamaya/osgi/commands/HistoryCommandsTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 30.09.2017.
@@ -36,22 +36,22 @@ public class HistoryCommandsTest extends AbstractOSGITest {
     public void clearHistory() throws Exception {
         ConfigHistory.configured("clearHistory1", "test");
         ConfigHistory.configured("clearHistory2", "test");
-        assertTrue(ConfigHistory.getHistory("clearHistory1").size()==1);
-        assertTrue(ConfigHistory.getHistory("clearHistory2").size()==1);
-        assertTrue(ConfigHistory.getHistory("clearHistory3").size()==0);
+        assertThat(ConfigHistory.getHistory("clearHistory1")).hasSize(1);
+        assertThat(ConfigHistory.getHistory("clearHistory2")).hasSize(1);
+        assertThat(ConfigHistory.getHistory("clearHistory3")).hasSize(0);
         String result = HistoryCommands.clearHistory(tamayaConfigPlugin, "clearHistory1");
-        assertTrue(result.contains("PID"));
-        assertTrue(result.contains("clearHistory1"));
-        assertTrue(ConfigHistory.getHistory("clearHistory1").size()==0);
-        assertTrue(ConfigHistory.getHistory("clearHistory2").size()==1);
-        assertTrue(ConfigHistory.getHistory("clearHistory3").size()==0);
+        assertThat(result.contains("PID")).isTrue();
+        assertThat(result.contains("clearHistory1")).isTrue();
+        assertThat(ConfigHistory.getHistory("clearHistory1")).hasSize(0);
+        assertThat(ConfigHistory.getHistory("clearHistory2")).hasSize(1);
+        assertThat(ConfigHistory.getHistory("clearHistory3")).hasSize(0);
         ConfigHistory.configured("clearHistory1", "test");
         result = HistoryCommands.clearHistory(tamayaConfigPlugin, "*");
-        assertTrue(result.contains("PID"));
-        assertTrue(result.contains("*"));
-        assertTrue(ConfigHistory.getHistory("clearHistory1").size()==0);
-        assertTrue(ConfigHistory.getHistory("clearHistory2").size()==0);
-        assertTrue(ConfigHistory.getHistory("clearHistory3").size()==0);
+        assertThat(result.contains("PID")).isTrue();
+        assertThat(result.contains("*")).isTrue();
+        assertThat(ConfigHistory.getHistory("clearHistory1")).hasSize(0);
+        assertThat(ConfigHistory.getHistory("clearHistory2")).hasSize(0);
+        assertThat(ConfigHistory.getHistory("clearHistory3")).hasSize(0);
 
     }
 
@@ -62,26 +62,26 @@ public class HistoryCommandsTest extends AbstractOSGITest {
         ConfigHistory.propertySet("getHistory", "k1", "v1", null);
         ConfigHistory.propertySet("getHistory", "k2", null, "v2");
         String result = HistoryCommands.getHistory(tamayaConfigPlugin, "getHistory");
-        assertNotNull(result);
-        assertTrue(result.contains("k1"));
-        assertTrue(result.contains("v1"));
-        assertTrue(result.contains("test"));
+        assertThat(result).isNotNull();
+        assertThat(result.contains("k1")).isTrue();
+        assertThat(result.contains("v1")).isTrue();
+        assertThat(result.contains("test")).isTrue();
         result = HistoryCommands.getHistory(tamayaConfigPlugin, "getHistory", ConfigHistory.TaskType.BEGIN.toString());
-        assertNotNull(result);
-        assertTrue(result.contains("getHistory"));
-        assertTrue(result.contains("test"));
-        assertFalse(result.contains("k1"));
-        assertFalse(result.contains("v2"));
+        assertThat(result).isNotNull();
+        assertThat(result.contains("getHistory")).isTrue();
+        assertThat(result.contains("test")).isTrue();
+        assertThat(result.contains("k1")).isFalse();
+        assertThat(result.contains("v2")).isFalse();
     }
 
     @Test
     public void getSetMaxHistorySize() throws Exception {
         String result = HistoryCommands.getMaxHistorySize(tamayaConfigPlugin);
-        assertEquals(result, String.valueOf(tamayaConfigPlugin.getMaxHistorySize()));
+        assertThat(result).isEqualTo(String.valueOf(tamayaConfigPlugin.getMaxHistorySize()));
         result = HistoryCommands.setMaxHistorySize(tamayaConfigPlugin, 111);
-        assertEquals(result, "tamaya-max-getHistory-getNumChilds=111");
+        assertThat(result).isEqualTo("tamaya-max-getHistory-getNumChilds=111");
         result = HistoryCommands.getMaxHistorySize(tamayaConfigPlugin);
-        assertEquals(result, "111");
+        assertThat(result).isEqualTo("111");
     }
 
 }

--- a/modules/osgi/gogo-shell/pom.xml
+++ b/modules/osgi/gogo-shell/pom.xml
@@ -55,10 +55,6 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/osgi/gogo-shell/pom.xml
+++ b/modules/osgi/gogo-shell/pom.xml
@@ -34,10 +34,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.tamaya.ext</groupId>
             <artifactId>tamaya-osgi</artifactId>
             <version>${project.parent.version}</version>
@@ -69,6 +65,10 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/modules/osgi/gogo-shell/src/test/java/org/apache/tamaya/gogo/shell/BackupCommandsTest.java
+++ b/modules/osgi/gogo-shell/src/test/java/org/apache/tamaya/gogo/shell/BackupCommandsTest.java
@@ -28,7 +28,6 @@ import java.util.Hashtable;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -86,7 +85,7 @@ public class BackupCommandsTest extends AbstractOSGITest{
             commands.tm_backup_delete("testBackup_Delete");
             return null;
         });
-        assertEquals("Backup deleted: testBackup_Delete".trim(), out.trim());
+        assertThat("Backup deleted: testBackup_Delete".trim()).isEqualTo(out.trim());
         verify(tamayaConfigPlugin).deleteBackup("testBackup_Delete");
     }
 

--- a/modules/osgi/gogo-shell/src/test/java/org/apache/tamaya/gogo/shell/ConfigCommandsTest.java
+++ b/modules/osgi/gogo-shell/src/test/java/org/apache/tamaya/gogo/shell/ConfigCommandsTest.java
@@ -28,8 +28,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
@@ -56,15 +55,14 @@ public class ConfigCommandsTest extends AbstractOSGITest{
             commands.tm_propertysources();
             return null;
         });
-        assertTrue(out.startsWith("Property Sources"));
-        assertTrue(out.contains(  "----------------"));
-        assertTrue(out.contains("ID"));
-        assertTrue(out.contains("Ordinal"));
-        assertTrue(out.contains("Class"));
-        assertTrue(out.contains("Size"));
-        assertTrue(out.contains("environment-properties"));
-        assertTrue(out.contains("system-properties"));
-
+        assertThat(out.startsWith("Property Sources")).isTrue();
+        assertThat(out.contains(  "----------------")).isTrue();
+        assertThat(out.contains("ID")).isTrue();
+        assertThat(out.contains("Ordinal")).isTrue();
+        assertThat(out.contains("Class")).isTrue();
+        assertThat(out.contains("Size")).isTrue();
+        assertThat(out.contains("environment-properties")).isTrue();
+        assertThat(out.contains("system-properties")).isTrue();
     }
 
     @Test
@@ -73,7 +71,7 @@ public class ConfigCommandsTest extends AbstractOSGITest{
             commands.tm_property("system-properties", "java.version", false);
             return null;
         });
-        assertEquals(System.getProperty("java.version").trim(), out.trim());
+        assertThat(System.getProperty("java.version").trim()).isEqualTo(out.trim());
     }
 
     @Test
@@ -82,10 +80,10 @@ public class ConfigCommandsTest extends AbstractOSGITest{
             commands.tm_property("system-properties", "java.version", true);
             return null;
         });
-        assertTrue(out.contains(System.getProperty("java.version")));
-        assertTrue(out.contains("Property Source"));
-        assertTrue(out.contains("Value"));
-        assertTrue(out.contains("system-properties"));
+        assertThat(out.contains(System.getProperty("java.version"))).isTrue();
+        assertThat(out.contains("Property Source")).isTrue();
+        assertThat(out.contains("Value")).isTrue();
+        assertThat(out.contains("system-properties")).isTrue();
     }
 
     @Test
@@ -94,20 +92,20 @@ public class ConfigCommandsTest extends AbstractOSGITest{
             commands.tm_propertysource("system-properties");
             return null;
         });
-        assertTrue(out.startsWith("Property Source"));
-        assertTrue(out.contains("ID"));
-        assertTrue(out.contains("system-properties"));
-        assertTrue(out.contains("Ordinal"));
-        assertTrue(out.contains("1000"));
-        assertTrue(out.contains("Class"));
-        assertTrue(out.contains("SystemPropertySource"));
-        assertTrue(out.contains("Properties"));
-        assertTrue(out.contains("Key"));
-        assertTrue(out.contains("Value"));
-        assertTrue(out.contains("Source"));
-        assertTrue(out.contains("Meta"));
-        assertTrue(out.contains("java.version"));
-        assertTrue(out.contains(System.getProperty("java.version")));
+        assertThat(out.startsWith("Property Source")).isTrue();
+        assertThat(out.contains("ID")).isTrue();
+        assertThat(out.contains("system-properties")).isTrue();
+        assertThat(out.contains("Ordinal")).isTrue();
+        assertThat(out.contains("1000")).isTrue();
+        assertThat(out.contains("Class")).isTrue();
+        assertThat(out.contains("SystemPropertySource")).isTrue();
+        assertThat(out.contains("Properties")).isTrue();
+        assertThat(out.contains("Key")).isTrue();
+        assertThat(out.contains("Value")).isTrue();
+        assertThat(out.contains("Source")).isTrue();
+        assertThat(out.contains("Meta")).isTrue();
+        assertThat(out.contains("java.version")).isTrue();
+        assertThat(out.contains(System.getProperty("java.version"))).isTrue();
     }
 
     @Test
@@ -119,30 +117,30 @@ public class ConfigCommandsTest extends AbstractOSGITest{
             commands.tm_config(null, "testConfig");
             return null;
         });
-        assertTrue(out.contains("Tamaya Configuration"));
-        assertTrue(out.contains("Section"));
-        assertTrue(out.contains("[testConfig]"));
-        assertTrue(out.contains("Configuration"));
+        assertThat(out.contains("Tamaya Configuration")).isTrue();
+        assertThat(out.contains("Section")).isTrue();
+        assertThat(out.contains("[testConfig]")).isTrue();
+        assertThat(out.contains("Configuration")).isTrue();
         out = runTest(() -> {
             commands.tm_config("java", "testConfig");
             return null;
         });
-        assertTrue(out.contains("Tamaya Configuration"));
-        assertTrue(out.contains("Section"));
-        assertTrue(out.contains("[testConfig]"));
-        assertTrue(out.contains("Filter"));
-        assertTrue(out.contains("java"));
-        assertTrue(out.contains("Configuration"));
+        assertThat(out.contains("Tamaya Configuration")).isTrue();
+        assertThat(out.contains("Section")).isTrue();
+        assertThat(out.contains("[testConfig]")).isTrue();
+        assertThat(out.contains("Filter")).isTrue();
+        assertThat(out.contains("java")).isTrue();
+        assertThat(out.contains("Configuration")).isTrue();
         out = runTest(() -> {
             commands.tm_config("java", "");
             return null;
         });
-        assertTrue(out.contains("Tamaya Configuration"));
-        assertTrue(out.contains("Section"));
-        assertTrue(out.contains("java"));
-        assertTrue(out.contains("Configuration"));
-        assertTrue(out.contains(".version"));
-        assertTrue(out.contains(System.getProperty("java.version")));
+        assertThat(out.contains("Tamaya Configuration")).isTrue();
+        assertThat(out.contains("Section")).isTrue();
+        assertThat(out.contains("java")).isTrue();
+        assertThat(out.contains("Configuration")).isTrue();
+        assertThat(out.contains(".version")).isTrue();
+        assertThat(out.contains(System.getProperty("java.version"))).isTrue();
     }
 
     @Test
@@ -154,31 +152,31 @@ public class ConfigCommandsTest extends AbstractOSGITest{
             commands.tm_apply_config("testApplyConfig", Policy.EXTEND, true);
             return null;
         });
-        assertTrue(out.contains("Applied Configuration"));
-        assertTrue(out.contains("PID"));
-        assertTrue(out.contains("testApplyConfig"));
-        assertTrue(out.contains("Policy"));
-        assertTrue(out.contains("EXTEND"));
-        assertTrue(out.contains("Dryrun"));
-        assertTrue(out.contains("true"));
-        assertTrue(out.contains("OSGI Configuration for PID"));
-        assertTrue(out.contains("test"));
-        assertTrue(out.contains("testVal"));
+        assertThat(out.contains("Applied Configuration")).isTrue();
+        assertThat(out.contains("PID")).isTrue();
+        assertThat(out.contains("testApplyConfig")).isTrue();
+        assertThat(out.contains("Policy")).isTrue();
+        assertThat(out.contains("EXTEND")).isTrue();
+        assertThat(out.contains("Dryrun")).isTrue();
+        assertThat(out.contains("true")).isTrue();
+        assertThat(out.contains("OSGI Configuration for PID")).isTrue();
+        assertThat(out.contains("test")).isTrue();
+        assertThat(out.contains("testVal")).isTrue();
         verify(tamayaConfigPlugin).updateConfig("testApplyConfig", Policy.EXTEND, true, true);
         out = runTest(() -> {
             commands.tm_apply_config("testApplyConfig", Policy.OVERRIDE, false);
             return null;
         });
-        assertTrue(out.contains("Applied Configuration"));
-        assertTrue(out.contains("PID"));
-        assertTrue(out.contains("testApplyConfig"));
-        assertTrue(out.contains("Policy"));
-        assertTrue(out.contains("OVERRIDE"));
-        assertTrue(out.contains("Dryrun"));
-        assertTrue(out.contains("false"));
-        assertTrue(out.contains("OSGI Configuration for PID"));
-        assertTrue(out.contains("test"));
-        assertTrue(out.contains("testVal"));
+        assertThat(out.contains("Applied Configuration")).isTrue();
+        assertThat(out.contains("PID")).isTrue();
+        assertThat(out.contains("testApplyConfig")).isTrue();
+        assertThat(out.contains("Policy")).isTrue();
+        assertThat(out.contains("OVERRIDE")).isTrue();
+        assertThat(out.contains("Dryrun")).isTrue();
+        assertThat(out.contains("false")).isTrue();
+        assertThat(out.contains("OSGI Configuration for PID")).isTrue();
+        assertThat(out.contains("test")).isTrue();
+        assertThat(out.contains("testVal")).isTrue();
         verify(tamayaConfigPlugin).updateConfig("testApplyConfig", Policy.OVERRIDE, true, false);
     }
 

--- a/modules/osgi/injection/pom.xml
+++ b/modules/osgi/injection/pom.xml
@@ -67,6 +67,10 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/modules/osgi/injection/pom.xml
+++ b/modules/osgi/injection/pom.xml
@@ -56,10 +56,6 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/osgi/injection/src/test/java/org/apache/tamaya/osgi/injection/ActivatorTest.java
+++ b/modules/osgi/injection/src/test/java/org/apache/tamaya/osgi/injection/ActivatorTest.java
@@ -28,9 +28,7 @@ import org.osgi.framework.ServiceReference;
 import java.util.Hashtable;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -69,19 +67,19 @@ public class ActivatorTest extends AbstractOSGITest{
         doReturn(bundle).when(reference).getBundle();
         doReturn(new Hashtable<>()).when(bundle).getHeaders();
         doReturn("true").when(reference).getProperty(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_PROP);
-        assertTrue(injectionService.isInjectionEnabled(reference));
+        assertThat(injectionService.isInjectionEnabled(reference)).isTrue();
         doReturn("yes").when(reference).getProperty(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_PROP);
-        assertTrue(injectionService.isInjectionEnabled(reference));
+        assertThat(injectionService.isInjectionEnabled(reference)).isTrue();
         doReturn("no").when(reference).getProperty(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_PROP);
-        assertFalse(injectionService.isInjectionEnabled(reference));
+        assertThat(injectionService.isInjectionEnabled(reference)).isFalse();
         doReturn(null).when(reference).getProperty(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_PROP);
-        assertFalse(injectionService.isInjectionEnabled(reference));
+        assertThat(injectionService.isInjectionEnabled(reference)).isFalse();
         doReturn("foo").when(reference).getProperty(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_PROP);
-        assertFalse(injectionService.isInjectionEnabled(reference));
+        assertThat(injectionService.isInjectionEnabled(reference)).isFalse();
         // service undefined, but bundle enabled
         doReturn(null).when(reference).getProperty(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_PROP);
         doReturn(singleHashtable(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_MANIFEST, "true")).when(bundle).getHeaders();
-        assertTrue(injectionService.isInjectionEnabled(reference));
+        assertThat(injectionService.isInjectionEnabled(reference)).isTrue();
     }
 
     private Hashtable singleHashtable(String key, String value) {
@@ -94,34 +92,34 @@ public class ActivatorTest extends AbstractOSGITest{
     public void isInjectionEnabled_Bundle() {
         Bundle bundle = mock(Bundle.class);
         doReturn(singleHashtable(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_MANIFEST, "true")).when(bundle).getHeaders();
-        assertTrue(injectionService.isInjectionEnabled(bundle));
+        assertThat(injectionService.isInjectionEnabled(bundle)).isTrue();
         doReturn(singleHashtable(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_MANIFEST, "YeS")).when(bundle).getHeaders();
-        assertTrue(injectionService.isInjectionEnabled(bundle));
+        assertThat(injectionService.isInjectionEnabled(bundle)).isTrue();
         doReturn(singleHashtable(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_MANIFEST, "on")).when(bundle).getHeaders();
-        assertTrue(injectionService.isInjectionEnabled(bundle));
+        assertThat(injectionService.isInjectionEnabled(bundle)).isTrue();
         doReturn(singleHashtable(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_MANIFEST, "TRUE")).when(bundle).getHeaders();
-        assertTrue(injectionService.isInjectionEnabled(bundle));
+        assertThat(injectionService.isInjectionEnabled(bundle)).isTrue();
         doReturn(singleHashtable(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_MANIFEST, "no")).when(bundle).getHeaders();
-        assertFalse(injectionService.isInjectionEnabled(bundle));
+        assertThat(injectionService.isInjectionEnabled(bundle)).isFalse();
         doReturn(singleHashtable(ConfigInjectionService.TAMAYA_INJECTION_ENABLED_MANIFEST, "foo")).when(bundle).getHeaders();
-        assertFalse(injectionService.isInjectionEnabled(bundle));
+        assertThat(injectionService.isInjectionEnabled(bundle)).isFalse();
         doReturn(new Hashtable<>()).when(bundle).getHeaders();
-        assertFalse(injectionService.isInjectionEnabled(bundle));
+        assertThat(injectionService.isInjectionEnabled(bundle)).isFalse();
     }
 
     @Test
     public void configure() throws Exception {
         Example example = new Example();
         Example result = injectionService.configure("tamaya", null, example);
-        assertNotNull(result);
-        assertTrue(result==example);
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(example);
         Example.checkExampleConfig(example);
     }
 
     @Test
     public void getConfiguredSupplier() throws Exception {
         Supplier<Example> supplier = injectionService.getConfiguredSupplier("tamaya", null, Example::new);
-        assertNotNull(supplier);
+        assertThat(supplier).isNotNull();
         Example example = supplier.get();
         Example.checkExampleConfig(example);
     }

--- a/modules/osgi/injection/src/test/java/org/apache/tamaya/osgi/injection/Example.java
+++ b/modules/osgi/injection/src/test/java/org/apache/tamaya/osgi/injection/Example.java
@@ -20,8 +20,7 @@ package org.apache.tamaya.osgi.injection;
 
 import org.apache.tamaya.inject.api.Config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Example class to be configured with injection.
@@ -35,17 +34,17 @@ final class Example {
     boolean javaUsed;
 
     static void checkExampleConfig(Example example) {
-        assertNotNull(example);
-        assertEquals(example.javaHome, System.getProperty("java.home"));
-        assertEquals(example.javaVersion, System.getProperty("java.version"));
-        assertEquals(example.javaUsed, true);
+        assertThat(example).isNotNull();
+        assertThat(example.javaHome).isEqualTo(System.getProperty("java.home"));
+        assertThat(example.javaVersion).isEqualTo(System.getProperty("java.version"));
+        assertThat(example.javaUsed).isTrue();
     }
 
     static void checkExampleConfig(TemplateExample template) {
-        assertNotNull(template);
-        assertEquals(template.getJavaHome(), System.getProperty("java.home"));
-        assertEquals(template.javaVersion(), System.getProperty("java.version"));
-        assertEquals(template.isJavaUsed(), true);
+        assertThat(template).isNotNull();
+        assertThat(template.getJavaHome()).isEqualTo(System.getProperty("java.home"));
+        assertThat(template.javaVersion()).isEqualTo(System.getProperty("java.version"));
+        assertThat(template.isJavaUsed()).isTrue();
     }
 
 }

--- a/modules/osgi/injection/src/test/java/org/apache/tamaya/osgi/injection/OSGIConfigAdminPropertySourceTest.java
+++ b/modules/osgi/injection/src/test/java/org/apache/tamaya/osgi/injection/OSGIConfigAdminPropertySourceTest.java
@@ -26,7 +26,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 03.10.2017.
@@ -43,43 +43,43 @@ public class OSGIConfigAdminPropertySourceTest extends AbstractOSGITest{
 
     @Test
     public void getPID() throws Exception {
-        assertEquals("tamaya", propertySource.getPid());
+        assertThat("tamaya").isEqualTo(propertySource.getPid());
     }
 
     @Test
     public void getLocation() throws Exception {
-        assertNull(propertySource.getLocation());
+        assertThat(propertySource.getLocation()).isNull();
     }
 
     @Test
     public void getDefaultOrdinal() throws Exception {
-        assertEquals(0, propertySource.getDefaultOrdinal());
+        assertThat(0).isEqualTo(propertySource.getDefaultOrdinal());
     }
 
     @Test
     public void getOrdinal() throws Exception {
-        assertEquals(0, propertySource.getOrdinal());
+        assertThat(0).isEqualTo(propertySource.getOrdinal());
     }
 
     @Test
     public void get() throws Exception {
         PropertyValue val = propertySource.get("java.home");
-        assertNotNull(val);
-        assertEquals(val.getKey(), "java.home");
-        assertEquals(val.getValue(), System.getProperty("java.home"));
+        assertThat(val).isNotNull();
+        assertThat(val.getKey()).isEqualTo("java.home");
+        assertThat(val.getValue()).isEqualTo(System.getProperty("java.home"));
         val = propertySource.get("foo.bar");
-        assertNull(val);
+        assertThat(val).isNull();
     }
 
     @Test
     public void getProperties() throws Exception {
         Map<String,PropertyValue> props = propertySource.getProperties();
-        assertNotNull(props);
+        assertThat(props).isNotNull();
         PropertyValue val = props.get("java.home");
-        assertEquals(val.getKey(), "java.home");
-        assertEquals(val.getValue(), System.getProperty("java.home"));
+        assertThat(val.getKey()).isEqualTo("java.home");
+        assertThat(val.getValue()).isEqualTo(System.getProperty("java.home"));
         val = props.get("foo.bar");
-        assertNull(val);
+        assertThat(val).isNull();
     }
 
 }

--- a/modules/osgi/injection/src/test/java/org/apache/tamaya/osgi/injection/OSGIConfigurationInjectorTest.java
+++ b/modules/osgi/injection/src/test/java/org/apache/tamaya/osgi/injection/OSGIConfigurationInjectorTest.java
@@ -24,7 +24,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.function.Supplier;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 03.10.2017.
@@ -35,13 +35,13 @@ public class OSGIConfigurationInjectorTest extends AbstractOSGITest{
     @Test
     public void getPid() throws Exception {
         OSGIConfigurationInjector injector = new OSGIConfigurationInjector(cm, "getPid");
-        assertEquals("getPid", injector.getPid());
+        assertThat("getPid").isEqualTo(injector.getPid());
     }
 
     @Test
     public void getLocation() throws Exception {
         OSGIConfigurationInjector injector = new OSGIConfigurationInjector(cm, "getLocation", "/test");
-        assertEquals("/test", injector.getLocation());
+        assertThat("/test").isEqualTo(injector.getLocation());
     }
 
     @Test
@@ -49,8 +49,8 @@ public class OSGIConfigurationInjectorTest extends AbstractOSGITest{
         OSGIConfigurationInjector injector = new OSGIConfigurationInjector(cm, "OSGIConfigurationInjectorTest");
         Example example = new Example();
         Example result = injector.configure(example);
-        assertNotNull(result);
-        assertTrue(result==example);
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(example);
         Example.checkExampleConfig(example);
     }
 
@@ -58,7 +58,7 @@ public class OSGIConfigurationInjectorTest extends AbstractOSGITest{
     public void getConfiguredSupplier() throws Exception {
         OSGIConfigurationInjector injector = new OSGIConfigurationInjector(cm, "OSGIConfigurationInjectorTest");
         Supplier<Example> supplier = injector.getConfiguredSupplier(Example::new);
-        assertNotNull(supplier);
+        assertThat(supplier).isNotNull();
         Example example = supplier.get();
         Example.checkExampleConfig(example);
     }

--- a/modules/osgi/updater/pom.xml
+++ b/modules/osgi/updater/pom.xml
@@ -75,10 +75,6 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/resolver/pom.xml
+++ b/modules/resolver/pom.xml
@@ -72,10 +72,6 @@ under the License.
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/modules/resolver/pom.xml
+++ b/modules/resolver/pom.xml
@@ -81,6 +81,10 @@ under the License.
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/modules/resolver/src/test/java/org/apache/tamaya/resolver/ConfigResolutionTest.java
+++ b/modules/resolver/src/test/java/org/apache/tamaya/resolver/ConfigResolutionTest.java
@@ -21,14 +21,12 @@ package org.apache.tamaya.resolver;
 import org.apache.tamaya.Configuration;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test class that test resolution of different values as configured within
@@ -38,98 +36,102 @@ public class ConfigResolutionTest {
 
     @Test
     public void test_Prefix_Resolution() {
-        assertEquals(Configuration.current().get("Before Text (prefixed)"), "My Java version is " + System.getProperty("java.version"));
+        assertThat(Configuration.current().get("Before Text (prefixed)"))
+            .isEqualTo("My Java version is " + System.getProperty("java.version"));
     }
 
     @Test
     public void test_Midfix_Resolution() {
-        assertEquals(Configuration.current().get("Before and After Text (prefixed)"), "My Java version is " + System.getProperty("java.version") + ".");
+        assertThat(Configuration.current().get("Before and After Text (prefixed)"))
+            .isEqualTo("My Java version is " + System.getProperty("java.version") + ".");
     }
 
     @Test
     public void test_Prefix_Resolution_BadSyntax1() {
-        assertEquals(Configuration.current().get("Will fail1."), "V$java.version");
+        assertThat(Configuration.current().get("Will fail1.")).isEqualTo("V$java.version");
     }
 
     @Test
     public void test_Prefix_Resolution_BadSyntax2() {
-        assertEquals(Configuration.current().get("Will fail2."), "V$java.version}");
+        assertThat(Configuration.current().get("Will fail2.")).isEqualTo("V$java.version}");
     }
 
     @Test
     public void test_Prefix_Resolution_BadSyntax31() {
-        assertEquals(Configuration.current().get("Will not fail3."), "V${java.version");
+        assertThat(Configuration.current().get("Will not fail3.")).isEqualTo("V${java.version");
     }
 
     @Test
     public void test_Prefix_Resolution_Escaped1() {
-        assertEquals(Configuration.current().get("Will not fail1."), "V$\\{java.version");
+        assertThat(Configuration.current().get("Will not fail1.")).isEqualTo("V$\\{java.version");
     }
 
     @Test
     public void test_Prefix_Resolution_Escaped2() {
-        assertEquals(Configuration.current().get("Will not fail2."), "V\\${java.version");
+        assertThat(Configuration.current().get("Will not fail2.")).isEqualTo("V\\${java.version");
     }
 
     @Test
     public void test_Prefix_Resolution_EnvKeys() {
-        assertEquals(Configuration.current().get("env.keys"), System.getProperty("java.version") + " plus $java.version");
+        assertThat(Configuration.current().get("env.keys"))
+            .isEqualTo(System.getProperty("java.version") + " plus $java.version");
     }
 
     @Test
     public void test_Prefix_ExpressionOnly_Resolution() {
-        assertEquals(Configuration.current().get("Expression Only"), System.getProperty("java.version"));
+        assertThat(Configuration.current().get("Expression Only")).isEqualTo(System.getProperty("java.version"));
     }
 
     @Test
     public void testConfig_Refs() {
-        assertEquals(Configuration.current().get("config-ref"), "Expression Only -> " + System.getProperty("java.version"));
-        assertEquals(Configuration.current().get("config-ref3"), "Config Ref 3 -> Ref 2: Config Ref 2 -> Ref 1: Expression Only -> " + System.getProperty("java.version"));
-        assertEquals(Configuration.current().get("config-ref2"), "Config Ref 2 -> Ref 1: Expression Only -> " + System.getProperty("java.version"));
+        assertThat(Configuration.current().get("config-ref"))
+            .isEqualTo("Expression Only -> " + System.getProperty("java.version"));
+        assertThat(Configuration.current().get("config-ref3"))
+            .isEqualTo("Config Ref 3 -> Ref 2: Config Ref 2 -> Ref 1: Expression Only -> " + System.getProperty("java.version"));
+        assertThat(Configuration.current().get("config-ref2"))
+            .isEqualTo("Config Ref 2 -> Ref 1: Expression Only -> " + System.getProperty("java.version"));
     }
 
     @Test
     public void testClasspath_Refs() {
         String value = Configuration.current().get("cp-ref");
-        assertNotNull(value);
-        assertTrue(value.contains("This content comes from Testresource.txt!"));
+        assertThat(value).isNotNull();
+        assertThat(value.contains("This content comes from Testresource.txt!")).isTrue();
     }
 
     @Test
     public void testResource_Refs() {
         String value = Configuration.current().get("res-ref");
-        assertNotNull(value);
-        assertTrue(value.contains("This content comes from Testresource.txt!"));
+        assertThat(value).isNotNull();
+        assertThat(value.contains("This content comes from Testresource.txt!")).isTrue();
     }
 
     @Test
     public void testFile_Refs() {
         String value = Configuration.current().get("file-ref");
-        assertNotNull(value);
-        assertTrue(value.contains("This content comes from Testresource2.txt!"));
+        assertThat(value).isNotNull();
+        assertThat(value.contains("This content comes from Testresource2.txt!")).isTrue();
     }
-    
+
     @Test
     public void testFile_Refs_doNotAppendNewLineAtTheEnd() throws Exception {
         String value = Configuration.current().get("file3-ref");
-        
         URI uri = getClass().getClassLoader().getResource("Testresource3.txt").toURI();
         byte[] byteContent = Files.readAllBytes(Paths.get(uri));
         String content = new String(byteContent, StandardCharsets.UTF_8);
-        
-        assertEquals(content, value);
+        assertThat(content).isEqualTo(value);
     }
 
     @Test
     public void testURL_Refs() {
         String value = Configuration.current().get("url-ref");
-        assertNotNull(value);
-        assertTrue(value.contains("doctype html") || "[http://www.google.com]".equals(value));
+        assertThat(value).isNotNull();
+        assertThat(value.contains("doctype html") || "[http://www.google.com]".equals(value)).isTrue();
     }
 
     @Test
     public void testEscaping(){
-        assertEquals(Configuration.current().get("escaped"),
+        assertThat(Configuration.current().get("escaped")).isEqualTo(
                 "Config Ref 3 -> Ref 2: \\${conf:config-ref2 will not be evaluated and will not contain\\t tabs \\n " +
                 "newlines or \\r returns...YEP!");
     }

--- a/modules/resolver/src/test/java/org/apache/tamaya/resolver/ResolverTest.java
+++ b/modules/resolver/src/test/java/org/apache/tamaya/resolver/ResolverTest.java
@@ -21,7 +21,7 @@ package org.apache.tamaya.resolver;
 import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link org.apache.tamaya.resolver.Resolver}.
@@ -30,41 +30,40 @@ public class ResolverTest {
 
     @Test
     public void testEvaluateExpression_withMask_NoKey() throws Exception {
-        assertEquals(Resolver.getInstance().evaluateExpression("Version ${java.foo}", true),
-                "Version ?{java.foo}");
+        assertThat(Resolver.getInstance().evaluateExpression("Version ${java.foo}", true))
+            .isEqualTo("Version ?{java.foo}");
     }
 
     @Test
     public void testEvaluateExpression_withMask_Classloader() throws Exception {
-        assertEquals(Resolver.getInstance(Thread.currentThread().getContextClassLoader())
-                .evaluateExpression("Version ${java.foo}", true),
-                "Version ?{java.foo}");
+        assertThat(Resolver.getInstance(Thread.currentThread().getContextClassLoader())
+                .evaluateExpression("Version ${java.foo}", true)).isEqualTo("Version ?{java.foo}");
     }
 
 
     @Test
     public void testEvaluateExpression() throws Exception {
-        assertEquals(Resolver.getInstance().evaluateExpression("myKey", "Version ${java.version}"),
-                "Version " + System.getProperty("java.version"));
+        assertThat(Resolver.getInstance().evaluateExpression("myKey", "Version ${java.version}"))
+            .isEqualTo("Version " + System.getProperty("java.version"));
     }
 
     @Test
     public void testEvaluateExpression_NoKey() throws Exception {
-        assertEquals(Resolver.getInstance().evaluateExpression("Version ${java.version}"),
-                "Version " + System.getProperty("java.version"));
+        assertThat(Resolver.getInstance().evaluateExpression("Version ${java.version}"))
+            .isEqualTo("Version " + System.getProperty("java.version"));
     }
 
     @Test
     public void testEvaluateExpression_ClassLoader() throws Exception {
-        assertEquals(Resolver.getInstance().evaluateExpression("myKey", "Version ${java.version}",
-                Thread.currentThread().getContextClassLoader()),
-                "Version " + System.getProperty("java.version"));
+        assertThat(Resolver.getInstance().evaluateExpression("myKey", "Version ${java.version}",
+                Thread.currentThread().getContextClassLoader()))
+            .isEqualTo("Version " + System.getProperty("java.version"));
     }
 
     @Test
     public void testEvaluateExpression1_NoKey_ClassLoader() throws Exception {
-        assertEquals(Resolver.getInstance().evaluateExpression("Version ${java.version}"),
-                "Version " + System.getProperty("java.version"));
+        assertThat(Resolver.getInstance().evaluateExpression("Version ${java.version}"))
+            .isEqualTo("Version " + System.getProperty("java.version"));
     }
 
     // TAMAYA-357
@@ -74,11 +73,10 @@ public class ResolverTest {
         String expression = "Test ${java.version},${java.foo},${"+envKey+"}";
         PropertyValue val = PropertyValue.createValue("AnyKey", expression);
         PropertyValue evaluated = (Resolver.getInstance().evaluateExpression(val, true));
-        assertNotNull(evaluated);
-        assertNotNull(evaluated.getMeta("resolvers"));
-        assertEquals("Test "+System.getProperty("java.version")+",?{java.foo},"+System.getenv(envKey),
-                val.getValue());
-        assertEquals("system-property, <unresolved>, environment-property, ", evaluated.getMeta("resolvers"));
+        assertThat(evaluated).isNotNull();
+        assertThat("Test " + System.getProperty("java.version") + ",?{java.foo}," + System.getenv(envKey))
+            .isEqualTo(val.getValue());
+        assertThat("system-property, <unresolved>, environment-property, ").isEqualTo(evaluated.getMeta("resolvers"));
     }
 
 }

--- a/modules/resources/pom.xml
+++ b/modules/resources/pom.xml
@@ -75,6 +75,10 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
             <version>5.0.0</version>

--- a/modules/resources/pom.xml
+++ b/modules/resources/pom.xml
@@ -67,10 +67,6 @@ under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/modules/resources/src/test/java/org/apache/tamaya/resource/AbstractPathPropertySourceProviderTest.java
+++ b/modules/resources/src/test/java/org/apache/tamaya/resource/AbstractPathPropertySourceProviderTest.java
@@ -31,8 +31,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AbstractPathPropertySourceProviderTest {
 
@@ -47,7 +46,7 @@ public class AbstractPathPropertySourceProviderTest {
 
     @Test
     public void testGetPropertySources() throws Exception {
-        assertNotNull(myProvider.getPropertySources());
+        assertThat(myProvider.getPropertySources()).isNotNull();
     }
 
     @Test
@@ -55,8 +54,8 @@ public class AbstractPathPropertySourceProviderTest {
         PropertySource ps = AbstractPathPropertySourceProvider.createPropertiesPropertySource(
                 ClassLoader.getSystemClassLoader().getResource("test.properties")
         );
-        assertNotNull(ps);
-        assertTrue(ps.getProperties().isEmpty());
+        assertThat(ps).isNotNull();
+        assertThat(ps.getProperties().isEmpty()).isTrue();
     }
 
     private static final class EmptyPropertySource implements PropertySource {

--- a/modules/resources/src/test/java/org/apache/tamaya/resource/internal/ClasspathCollectorTest.java
+++ b/modules/resources/src/test/java/org/apache/tamaya/resource/internal/ClasspathCollectorTest.java
@@ -23,7 +23,7 @@ import org.junit.Ignore;
 import java.net.URL;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This tests is using testing the classpath collector functionality, either by accessing/searching entries
@@ -35,53 +35,53 @@ public class ClasspathCollectorTest {
     public void testCollectAllClasses() throws Exception {
         ClasspathCollector cpc = new ClasspathCollector(Thread.currentThread().getContextClassLoader());
         Collection<URL> found = cpc.collectFiles("classpath:javax/annotation/*.class");
-        assertEquals(8, found.size()); // 7 ordinary, 1 inner class.
+        assertThat(found).hasSize(8); // 7 ordinary, 1 inner class.
         Collection<URL> found2 = cpc.collectFiles("javax/annotation/*.class");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 
     @org.junit.Test
     public void testCollectAllInPackage() throws Exception {
         ClasspathCollector cpc = new ClasspathCollector(Thread.currentThread().getContextClassLoader());
         Collection<URL> found = cpc.collectFiles("classpath:javax/**/sql/*.class");
-        assertEquals(2, found.size());
+        assertThat(found).hasSize(2);
         Collection<URL> found2 = cpc.collectFiles("javax/**/sql/*.class");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 
     @org.junit.Test
     public void testCollectClassNames() throws Exception {
         ClasspathCollector cpc = new ClasspathCollector(Thread.currentThread().getContextClassLoader());
         Collection<URL> found = cpc.collectFiles("classpath:javax/annotation/**/R*.class");
-        assertEquals(2, found.size());
+        assertThat(found).hasSize(2);
         Collection<URL> found2 = cpc.collectFiles("javax/annotation/**/R*.class");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 
     @org.junit.Test
     public void testCollectWithExpression() throws Exception {
         ClasspathCollector cpc = new ClasspathCollector(Thread.currentThread().getContextClassLoader());
         Collection<URL> found = cpc.collectFiles("classpath:javax/annotation/R?so*.class");
-        assertEquals(3, found.size());
+        assertThat(found).hasSize(3);
         Collection<URL> found2 = cpc.collectFiles("javax/annotation/R?so*.class");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 
     @org.junit.Test
     public void testCollectResources() throws Exception {
         ClasspathCollector cpc = new ClasspathCollector(Thread.currentThread().getContextClassLoader());
         Collection<URL> found = cpc.collectFiles("classpath:META-INF/maven/org.apache.geronimo.specs/**/*");
-        assertEquals(3, found.size());
+        assertThat(found).hasSize(3);
         Collection<URL> found2 = cpc.collectFiles("META-INF/maven/org.apache.geronimo.specs/**/*");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 
     @org.junit.Test
     public void testCollectResourcesFromLocalFSPath() throws Exception {
         ClasspathCollector cpc = new ClasspathCollector(Thread.currentThread().getContextClassLoader());
         Collection<URL> found = cpc.collectFiles("classpath:resources_testroot/**/*.file");
-        assertEquals(7, found.size());
+        assertThat(found).hasSize(7);
         Collection<URL> found2 = cpc.collectFiles("resources_testroot/**/*.file");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 }

--- a/modules/resources/src/test/java/org/apache/tamaya/resource/internal/DefaultResourceResolverTest.java
+++ b/modules/resources/src/test/java/org/apache/tamaya/resource/internal/DefaultResourceResolverTest.java
@@ -18,14 +18,14 @@
  */
 package org.apache.tamaya.resource.internal;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collection;
 
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the {@link org.apache.tamaya.resource.internal.DefaultResourceResolver} using CP and FS path expressions.
@@ -38,18 +38,18 @@ public class DefaultResourceResolverTest {
     @Test
     public void testGetResources_CP() throws Exception {
         Collection<URL> found = resolver.getResources("classpath:resources_testroot/**/*.file");
-        assertEquals(7, found.size());
+        assertThat(found).hasSize(7);
         Collection<URL> found2 = resolver.getResources("resources_testroot/**/*.file");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 
     @Test
     public void testGetResources_FS() throws Exception {
         String resDir = getResourceDir();
         Collection<URL> found = resolver.getResources("file:" + resDir + "/resources_testroot/aa?a/*.file");
-        assertEquals(5, found.size());
+        assertThat(found).hasSize(5);
         Collection<URL> found2 = resolver.getResources(resDir + "/resources_testroot/aa?a/*.file");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 
     private String getResourceDir() throws URISyntaxException {

--- a/modules/resources/src/test/java/org/apache/tamaya/resource/internal/FileCollectorTest.java
+++ b/modules/resources/src/test/java/org/apache/tamaya/resource/internal/FileCollectorTest.java
@@ -25,7 +25,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for checking correct lookup using the filesystem.
@@ -44,18 +44,18 @@ public class FileCollectorTest {
     public void testCollectResourcesFromLocalFSPath() throws Exception {
         String resDir = getResourceDir();
         Collection<URL> found = FileCollector.collectFiles("file:" + resDir + "/**/*.file");
-        assertEquals(7, found.size());
+        assertThat(found).hasSize(7);
         Collection<URL> found2 = FileCollector.collectFiles(resDir + "/**/*.file");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 
     @Test
     public void testCollectResourcesFromLocalFSPath_WithFolderPlaceholder() throws Exception {
         String resDir = getResourceDir();
         Collection<URL> found = FileCollector.collectFiles("file:" + resDir + "/aa?a/*.file");
-        assertEquals(5, found.size());
+        assertThat(found).hasSize(5);
         Collection<URL> found2 = FileCollector.collectFiles(resDir + "/aa?a/*.file");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 
 
@@ -63,9 +63,9 @@ public class FileCollectorTest {
     public void testCollectResourcesFromLocalFSPath_WithFolderAny() throws Exception {
         String resDir = getResourceDir();
         Collection<URL> found = FileCollector.collectFiles("file:" + resDir + "/b*/b?/*.file");
-        assertEquals(1, found.size());
+        assertThat(found).hasSize(1);
         Collection<URL> found2 = FileCollector.collectFiles(resDir + "/b*/b?/*.file");
-        assertEquals(found, found2);
+        assertThat(found).isEqualTo(found2);
     }
 
 

--- a/modules/spring/pom.xml
+++ b/modules/spring/pom.xml
@@ -68,11 +68,6 @@ under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@ under the License.
         <enforcer.version>3.0.0-M1</enforcer.version>
         <gem.plugin>1.0.7</gem.plugin>
         <sources.plugin>3.0.1</sources.plugin>
-        <hamcrest.version>2.0.0.0</hamcrest.version>
         <javadoc.version>3.0.1</javadoc.version>
         <!-- Must/should match the JRuby version used by AsciidoctorJ -->
         <jruby.version>1.7.26</jruby.version>
@@ -233,12 +232,6 @@ under the License.
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-core</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
@@ -259,25 +252,12 @@ under the License.
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-core</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>${findbugs.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>java-hamcrest</artifactId>
-                <version>${hamcrest.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This migrates all of the test assertions from a combination of junit/hamcrest/assertj to only use the AssertJ library. It also removes the direct dependency on hamcrest.