### PR TITLE
TAMAYA-219: Enable checkstyle analysis

### DIFF
--- a/buildtools/src/main/resources/checkstyle/style.xml
+++ b/buildtools/src/main/resources/checkstyle/style.xml
@@ -1,0 +1,169 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="SuppressionCommentFilter"/>
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="FileLength">
+        <property name="max" value="3500"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="FileTabCharacter"/>
+
+
+    <module name="TreeWalker">
+        <!-- needed for the SuppressionCommentFilter -->
+        <module name="FileContentsHolder"/>
+
+        <!-- Checks for Javadoc comments.                     -->
+        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+        <!-- module name="JavadocMethod"/ -->
+        <module name="JavadocType"/>
+        <!-- module name="JavadocVariable"/ -->
+
+
+        <!-- Checks for Naming Conventions.                  -->
+        <!-- See http://checkstyle.sf.net/config_naming.html -->
+        <!--
+                <module name="MemberName">
+                  <property name="format" value="^_[a-z][a-zA-Z0-9]*$" />
+                </module>
+        -->
+
+        <module name="ConstantName">
+            <!-- Normal rules, except that:
+               -  * any name can start with an underscore.
+               -  * "log" is allowed; this is a traditional name for log objects
+               -  * names ending with "ThreadLocal" are allowed so that threadlocal vars don't have to be
+               -    all-caps. They are static final, but are not really constants. Yes, type prefixes
+               -    on variable names sucks ("hungarian notation") but checkstyle doesn't allow
+               -    name rules to vary by the type of the constant, and no other alternative seems
+               -    any better.
+               -->
+            <property name="format"
+                      value="^_?((log)|(logger)|([a-z][a-zA-Z]*ThreadLocal)|([A-Z][A-Z0-9]*(_[A-Z0-9]+)*))$"/>
+        </module>
+
+        <module name="LocalVariableName"/>
+        <module name="MethodName">
+            <property name="format"
+                      value="^_?[a-z][a-zA-Z0-9]*$"/>
+        </module>
+        <module name="PackageName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName">
+            <property name="format"
+                      value="^_?[A-Z][a-zA-Z0-9]*$"/>
+        </module>
+
+        <!-- Checks for imports                              -->
+        <!-- See http://checkstyle.sf.net/config_import.html -->
+        <module name="AvoidStarImport">
+            <property name="excludes"
+                      value="java.io,java.net,java.util"/>
+        </module>
+        <module name="IllegalImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+
+
+        <module name="LineLength">
+            <property name="max" value="180"/>
+            <property name="ignorePattern"
+                      value="@version|@see"/>
+        </module>
+        <module name="MethodLength">
+            <property name="max" value="250"/>
+        </module>
+        <module name="ParameterNumber">
+            <property name="max" value="10"/>
+        </module>
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See http://checkstyle.sf.net/config_blocks.html -->
+        <module name="EmptyBlock">
+            <property name="option" value="text"/>
+        </module>
+
+        <module name="NeedBraces"/>
+        <module name="LeftCurly">
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="RightCurly">
+            <property name="option" value="SAME"/>
+        </module>
+
+        <!-- Checks for common coding problems               -->
+        <!-- See http://checkstyle.sf.net/config_coding.html -->
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="DefaultComesLast"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="MultipleVariableDeclarations"/>
+
+        <!-- Checks for class design                         -->
+        <!-- See http://checkstyle.sf.net/config_design.html -->
+        <!-- module name="DesignForExtension"/ -->
+        <module
+            name="com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck">
+            <property name="severity" value="ignore"/>
+        </module>
+
+        <!-- module name="FinalClass"/ -->
+
+        <module name="HideUtilityClassConstructor"/>
+
+        <!-- module name="InterfaceIsType"/ -->
+        <!-- module name="VisibilityModifier"/ -->
+
+        <module
+            name="com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck">
+            <property name="packageAllowed" value="false"/>
+            <property name="protectedAllowed" value="true"/>
+            <property name="publicMemberPattern"
+                      value="^serialVersionUID"/>
+            <property name="severity" value="warning"/>
+        </module>
+
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See http://checkstyle.sf.net/config_misc.html -->
+        <!-- module name="ArrayTypeStyle"/ -->
+        <!-- module name="FinalParameters"/ -->
+        <!-- Line with Trailing Spaces (disabled as it's to noisy)
+        <module name="GenericIllegalRegexp">
+            <property name="format" value="\s+$" />
+            <property name="message" value="Line has trailing spaces." />
+        </module>
+          -->
+        <module name="UpperEll"/>
+
+    </module>
+
+</module>

--- a/buildtools/src/main/resources/findbugs/findbugs-exclude.xml
+++ b/buildtools/src/main/resources/findbugs/findbugs-exclude.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<FindBugsFilter>
+    <Match>
+        <!-- Also catches simple anonamous classes... -->
+        <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+    </Match>
+
+    <Match>
+        <!-- Note: @todo Write a bug report
+          The current version of FindBugs (version 3.0.0) is not able to detect
+          the usage of this method via a method reference.
+          Oliver B. Fischer, 17.01.2015
+        -->
+        <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
+    </Match>
+
+    <Match>
+        <!-- Note: @todo Write a bug report
+          The current version of FindBugs (version 3.0.0) is not able to detect
+          correctly caught exceptions.
+          Oliver B. Fischer, 09.02.2015
+        -->
+        <Bug pattern="REC_CATCH_EXCEPTION"/>
+    </Match>
+
+    <Match>
+        <!-- Note: We will not fail because of an unread field. -->
+        <Bug pattern="URF_UNREAD_FIELD" />
+    </Match>
+
+    <Match>
+        <!-- Note: We will not fail because of an unused field -->
+        <Bug pattern="UUF_UNUSED_FIELD" />
+    </Match>
+
+    <Match>
+        <Class name='org.apache.tamaya.integration.cdi.TamayaCDIIntegration'/>
+        <Method name="initBeanManager"/>
+    </Match>
+
+    <Match>
+        <!-- Note:
+             Intended. See the inline comment on this issue in the source file
+             in revision ae66299e25b41167008021ffe95cad236f6e2bd3
+             Oliver B. Fischer, 17.01.2015
+          -->
+        <Class name='org.apache.tamaya.resource.internal.ClasspathCollector'/>
+        <Method name="doFindPathMatchingJarResources"
+                returns="java.util.Collection"/>
+        <Bug pattern="OS_OPEN_STREAM"/>
+
+    </Match>
+
+    <!-- False positive returnin null for Boolean is required by the implemented interface. -->
+    <Match>
+        <Class name="org.apache.tamaya.core.internal.converters.BooleanConverter"/>
+    </Match>
+
+    <!-- False positive: example class used for config demo. -->
+    <Match>
+        <Class name="org.apache.tamaya.examples.injection.Example"/>
+    </Match>
+
+    <!--
+     * findBugs does not detect usage via method references
+     * should be removed after see TODO ProgrammaticConfigurationContext:131
+    -->
+
+    <!-- Issues to review -->
+
+    <Match>
+        <Package name="org.apache.tamaya.core.internal"/>
+    </Match>
+
+    <!--<Match>-->
+        <!--<Class name="org.apache.tamaya.resolver.internal.ResourceResolver" />-->
+    <!--</Match>-->
+    <!--<Match>-->
+        <!--<Class name="org.apache.tamaya.resolver.internal.FileResolver" />-->
+    <!--</Match>-->
+    <!--<Match>-->
+        <!--<Class name="org.apache.tamaya.resolver.internal.DefaultExpressionEvaluator" />-->
+    <!--</Match>-->
+    <!--<Match>-->
+        <!--<Class name="org.apache.tamaya.inject.internal.ConfiguredSetterMethod" />-->
+    <!--</Match>-->
+    <Match>
+        <Class name="org.apache.tamaya.inject.internal.ConfigChangeCallbackMethod" />
+    </Match>
+
+    <Match>
+        <Class name="org.apache.tamaya.events.internal.DefaultConfigChangeObserver" />
+        <Method name="checkConfigurationUpdate" />
+    </Match>
+
+    <Match>
+        <Class name="org.apache.tamaya.inject.internal.DefaultDynamicValue"/>
+    </Match>
+    <Match>
+        <Class name="org.apache.tamaya.integration.cdi.DefaultDynamicValue"/>
+    </Match>
+    <Match>
+        <!-- Imported from APache Felix. -->
+        <Class name="org.apache.tamaya.integration.osgi.felix.FilePersistenceManager"/>
+    </Match>
+    <Match>
+        <!-- Imported from APache Felix. -->
+        <Class name="org.apache.tamaya.integration.osgi.felix.ConfigurationHandler"/>
+    </Match>
+    <Match>
+        <Class name="org.apache.tamaya.integration.osgi.injection.Activator"/>
+    </Match>
+    <Match>
+        <Class name="org.apache.tamaya.resource.internal.FileCollector"/>
+        <Method name="traverseAndSelectFromChildren"/>
+    </Match>
+
+</FindBugsFilter>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -51,4 +51,13 @@ under the License.
         <module>consul</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -413,15 +413,10 @@ under the License.
                     <configuration>
                         <logViolationsToConsole>true</logViolationsToConsole>
                         <failOnViolation>false</failOnViolation>
-                        <configLocation>checkstyle/style.xml</configLocation>
+                        <configLocation>buildtools/src/main/resources/checkstyle/style.xml</configLocation>
                     </configuration>
 
                     <dependencies>
-                        <dependency>
-                            <groupId>org.apache.tamaya</groupId>
-                            <artifactId>buildconfigurations</artifactId>
-                            <version>${tamaya-apicore.version}</version>
-                        </dependency>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
@@ -466,15 +461,8 @@ under the License.
                         <effort>Max</effort>
                         <threshold>Low</threshold>
                         <failOnError>true</failOnError>
-                        <excludeFilterFile>findbugs/findbugs-exclude.xml</excludeFilterFile>
+                        <excludeFilterFile>buildtools/src/main/resources/findbugs/findbugs-exclude.xml</excludeFilterFile>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.tamaya</groupId>
-                            <artifactId>buildconfigurations</artifactId>
-                            <version>${tamaya-apicore.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
 
                 <plugin>
@@ -879,10 +867,6 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 
@@ -1099,6 +1083,18 @@ under the License.
                 <configuration>
                     <skip>false</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${checkstyle.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>checkstyle</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ under the License.
         <asciidoctor-diagramm.version>1.2.1</asciidoctor-diagramm.version>
         <asciidoctorj.version>1.5.6</asciidoctorj.version>
         <assembly.version>3.1.0</assembly.version>
-        <checkstyle.version>2.15</checkstyle.version>
+        <checkstyle.version>3.0.0</checkstyle.version>
         <enforcer.version>3.0.0-M1</enforcer.version>
         <gem.plugin>1.0.7</gem.plugin>
         <sources.plugin>3.0.1</sources.plugin>
@@ -403,8 +403,8 @@ under the License.
                     <version>${checkstyle.version}</version>
                     <executions>
                         <execution>
-                            <id>verify-style</id>
-                            <phase>process-classes</phase>
+                            <id>checkstyle</id>
+                            <phase>validate</phase>
                             <goals>
                                 <goal>check</goal>
                             </goals>
@@ -412,6 +412,7 @@ under the License.
                     </executions>
                     <configuration>
                         <logViolationsToConsole>true</logViolationsToConsole>
+                        <failOnViolation>false</failOnViolation>
                         <configLocation>checkstyle/style.xml</configLocation>
                     </configuration>
 
@@ -424,7 +425,7 @@ under the License.
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>7.3</version>
+                            <version>7.8</version>
                             <exclusions><!-- MCHECKSTYLE-156 -->
                                 <exclusion>
                                     <groupId>com.sun</groupId>
@@ -877,6 +878,10 @@ under the License.
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This enables checkstyle analysis on the extension modules. Errors will be reported to the console but will not (at present) fail a build.