### PR TITLE
TAMAYA-291: Increase code coverage for etcd module

### DIFF
--- a/modules/etcd/pom.xml
+++ b/modules/etcd/pom.xml
@@ -76,17 +76,4 @@ under the License.
         </dependency>
     </dependencies>
 
-    <build>
-      <plugins>
-        <plugin>
-            <groupId>org.pitest</groupId>
-            <artifactId>pitest-maven</artifactId>
-            <configuration>
-                <mutationThreshold>7</mutationThreshold>
-                <verbose>true</verbose>
-            </configuration>
-        </plugin>
-      </plugins>
-    </build>
-
 </project>

--- a/modules/etcd/src/test/java/org/apache/tamaya/etcd/EtcdBackendConfigTest.java
+++ b/modules/etcd/src/test/java/org/apache/tamaya/etcd/EtcdBackendConfigTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tamaya.etcd;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EtcdBackendConfigTest {
+
+    @Test
+    public void testEtcdDirectoryProperty() throws Exception {
+        final String directory = "./target/etcd-data";
+        try {
+            System.setProperty("tamaya.etcd.directory", directory);
+            assertThat(EtcdBackendConfig.getEtcdDirectory()).isEqualTo(directory);
+        } finally {
+            System.clearProperty("tamaya.etcd.directory");
+        }
+    }
+
+    @Test
+    public void testEtcdTimeoutProperty() throws Exception {
+        try {
+            assertThat(EtcdBackendConfig.getEtcdTimeout()).isEqualTo(2000L);
+            System.setProperty("tamaya.etcd.timeout", "5");
+            assertThat(EtcdBackendConfig.getEtcdTimeout()).isEqualTo(5000L);
+        } finally {
+            System.clearProperty("tamaya.etcd.timeout");
+        }
+    }
+
+    @Test
+    public void testEtcdServerProperty() throws Exception {
+        final String server = "http://localhost:4001";
+        try {
+            assertThat(EtcdBackendConfig.getServers()).contains("http://127.0.0.1:4001");
+            System.setProperty("tamaya.etcd.server", server);
+            assertThat(EtcdBackendConfig.getServers()).contains(server);
+        } finally {
+            System.clearProperty("tamaya.etcd.server");
+        }
+    }
+}

--- a/modules/etcd/src/test/java/org/apache/tamaya/etcd/EtcdPropertySourceTest.java
+++ b/modules/etcd/src/test/java/org/apache/tamaya/etcd/EtcdPropertySourceTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -70,5 +71,17 @@ public class EtcdPropertySourceTest {
     @Test
     public void testIsScannable() throws Exception {
         assertThat(propertySource.isScannable()).isTrue();
+    }
+
+    @Test
+    public void testPropertySourceConstructorParams() throws Exception {
+        EtcdPropertySource propertySource = new EtcdPropertySource("http://8.8.8.8:4001", "http://192.168.99.105:4001");
+        assertThat(propertySource.getProperties()).isNotNull();
+    }
+
+    @Test
+    public void testPropertySourceConstructorList() throws Exception {
+        EtcdPropertySource propertySource = new EtcdPropertySource(asList("http://8.8.8.8:4001", "http://192.168.99.105:4001"));
+        assertThat(propertySource.getProperties()).isNotNull();
     }
 }


### PR DESCRIPTION
This increases the code coverage for the etcd module, allowing us to remove the PIT test threshold exception for this module.

N.B. the reason the coverage threshold changed had to do with the change in line numbers from the earlier commit, i.e.:

```java
if(x == true) return;
```

became

```java
if (x == true) {
    return;
}
```

And the increase in line numbers dropped the coverage statistics.